### PR TITLE
Add an initial witx file for I/O Streams.

### DIFF
--- a/standard/io/docs.md
+++ b/standard/io/docs.md
@@ -1482,7 +1482,7 @@ Read bytes from an input byte stream source.
 On success, `$size` indicates the number of bytes read, and
 `$read_status` indicates the state of the stream.
 
-When `$read_status` is `$read`, `$size` is equal to the total buffer size
+When `$read_status` is `$ready`, `$size` is equal to the total buffer size
 of `$iovs`.
 
 When `$read_status` is `$end`, or on failure, subsequent calls to [`read`](#read)
@@ -1526,7 +1526,7 @@ Consume bytes from an input byte stream source, discarding the data.
 On success, `$size` indicates the number of bytes read, and
 `$read_status` indicates the state of the stream.
 
-When `$read_status` is `$read`, `$size` is equal to the total buffer size
+When `$read_status` is `$ready`, `$size` is equal to the total buffer size
 of `$iovs`.
 
 When `$read_status` is `$end`, or on failure, subsequent calls to [`read`](#read)
@@ -1730,7 +1730,7 @@ The pseudonym.
 ---
 
 #### <a href="#write_pseudonym" name="write_pseudonym"></a> `write_pseudonym(source: output_byte_stream, name: pseudonym) -> Result<(), ()>`
-Write a pseudonym's nameto the output stream.
+Write a pseudonym's name to the output stream.
 
 This function traps if the pseudonym is not one obtained from calling
 [`input_pseudonym`](#input_pseudonym) or [`output_pseudonym`](#output_pseudonym) with a `$where` parameter of
@@ -1742,11 +1742,14 @@ exposed.
 
 ##### Params
 - <a href="#write_pseudonym.source" name="write_pseudonym.source"></a> `source`: [`output_byte_stream`](#output_byte_stream)
+The output to write to.
 
 - <a href="#write_pseudonym.name" name="write_pseudonym.name"></a> `name`: [`pseudonym`](#pseudonym)
+The pseudonym representing the name to write.
 
 ##### Results
 - <a href="#write_pseudonym.result" name="write_pseudonym.result"></a> `result`: `Result<(), ()>`
+Indicate success or failure.
 
 ###### Variant cases
 - <a href="#write_pseudonym.result.ok" name="write_pseudonym.result.ok"></a> `ok`
@@ -1786,7 +1789,7 @@ On success, return the number of bytes forwarded.
 ---
 
 #### <a href="#forward_n" name="forward_n"></a> `forward_n(source: input_byte_stream, sink: output_byte_stream, len: size) -> Result<(size, read_status), ()>`
-Forward up to `$n` bytes from an input stream to an output stream.
+Forward up to `$len` bytes from an input stream to an output stream.
 
 If a failure occurs on the output stream, the remaining data from the
 input stream is consumed and discarded.
@@ -1833,8 +1836,10 @@ transmitted to the output.
 ##### Params
 ##### Results
 - <a href="#pipe.source" name="pipe.source"></a> `source`: [`input_byte_stream`](#input_byte_stream)
+A stream for reading from the created pipe.
 
 - <a href="#pipe.sink" name="pipe.sink"></a> `sink`: [`output_byte_stream`](#output_byte_stream)
+A stream for writing to the created pipe.
 
 
 ---
@@ -1845,4 +1850,5 @@ Return an output stream which discards data sent to it.
 ##### Params
 ##### Results
 - <a href="#null.sink" name="null.sink"></a> `sink`: [`output_byte_stream`](#output_byte_stream)
+A stream for writing bytes to be discarded.
 

--- a/standard/io/docs.md
+++ b/standard/io/docs.md
@@ -1756,8 +1756,11 @@ exposed.
 
 ---
 
-#### <a href="#forward" name="forward"></a> `forward(source: input_byte_stream, sink: output_byte_stream) -> (size, size, Result<(), errno>)`
+#### <a href="#forward" name="forward"></a> `forward(source: input_byte_stream, sink: output_byte_stream) -> Result<size, ()>`
 Forward all the subsequent data from an input stream to an output stream.
+
+If a failure occurs on the output stream, the remaining data from the
+input stream is consumed and discarded.
 
 ##### Params
 - <a href="#forward.source" name="forward.source"></a> `source`: [`input_byte_stream`](#input_byte_stream)
@@ -1767,29 +1770,26 @@ The input to read from.
 The output to write to.
 
 ##### Results
-- <a href="#forward.num_read" name="forward.num_read"></a> `num_read`: [`size`](#size)
-The number of bytes read.
-
-- <a href="#forward.num_written" name="forward.num_written"></a> `num_written`: [`size`](#size)
-The number of bytes written.
-
-- <a href="#forward.result" name="forward.result"></a> `result`: `Result<(), errno>`
-Success or error.
+- <a href="#forward.result" name="forward.result"></a> `result`: `Result<size, ()>`
+On success, return the number of bytes forwarded.
 
 ###### Variant Layout
 - size: 8
 - align: 4
 - tag_size: 4
 ###### Variant cases
-- <a href="#forward.result.ok" name="forward.result.ok"></a> `ok`
+- <a href="#forward.result.ok" name="forward.result.ok"></a> `ok`: [`size`](#size)
 
-- <a href="#forward.result.err" name="forward.result.err"></a> `err`: [`errno`](#errno)
+- <a href="#forward.result.err" name="forward.result.err"></a> `err`
 
 
 ---
 
-#### <a href="#forward_n" name="forward_n"></a> `forward_n(source: input_byte_stream, sink: output_byte_stream, len: size) -> (size, size, Result<(), errno>)`
+#### <a href="#forward_n" name="forward_n"></a> `forward_n(source: input_byte_stream, sink: output_byte_stream, len: size) -> Result<(size, read_status), ()>`
 Forward up to `$n` bytes from an input stream to an output stream.
+
+If a failure occurs on the output stream, the remaining data from the
+input stream is consumed and discarded.
 
 ##### Params
 - <a href="#forward_n.source" name="forward_n.source"></a> `source`: [`input_byte_stream`](#input_byte_stream)
@@ -1802,23 +1802,26 @@ The output to write to.
 The maximum number of bytes to forward.
 
 ##### Results
-- <a href="#forward_n.num_read" name="forward_n.num_read"></a> `num_read`: [`size`](#size)
-The number of bytes read.
-
-- <a href="#forward_n.num_written" name="forward_n.num_written"></a> `num_written`: [`size`](#size)
-The number of bytes written.
-
-- <a href="#forward_n.result" name="forward_n.result"></a> `result`: `Result<(), errno>`
-Success or error.
+- <a href="#forward_n.result" name="forward_n.result"></a> `result`: `Result<(size, read_status), ()>`
+On success, returns the number of bytes forwarded plus the stream status.
 
 ###### Variant Layout
-- size: 8
+- size: 12
 - align: 4
 - tag_size: 4
 ###### Variant cases
-- <a href="#forward_n.result.ok" name="forward_n.result.ok"></a> `ok`
+- <a href="#forward_n.result.ok" name="forward_n.result.ok"></a> `ok`: `(size, read_status)`
 
-- <a href="#forward_n.result.err" name="forward_n.result.err"></a> `err`: [`errno`](#errno)
+####### Record members
+- <a href="#forward_n.result.ok.0" name="forward_n.result.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#forward_n.result.ok.1" name="forward_n.result.ok.1"></a> `1`: [`read_status`](#read_status)
+
+Offset: 4
+
+- <a href="#forward_n.result.err" name="forward_n.result.err"></a> `err`
 
 
 ---

--- a/standard/io/docs.md
+++ b/standard/io/docs.md
@@ -1713,6 +1713,10 @@ handle, which can be written to the `$where` output byte stream.
 This allows the name of the output sink to be passed into APIs
 which display the name.
 
+TODO: This needs to say something about how the name is displayed.
+Can it include whitespace? Non-printing characters? Quotes?
+Backslashes? What's the encoding? And more.
+
 ##### Params
 - <a href="#output_pseudonym.source" name="output_pseudonym.source"></a> `source`: [`output_byte_stream`](#output_byte_stream)
 The output byte stream to request a pseudonym for.

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -1,32 +1,225 @@
 ;; WASI I/O Streams.
+;;
+;; Many parts of this file are expected to evolve, as witx evolves, as
+;; interface types evolves, and as the I/O Types concepts themselves evolve.
+;; For example, `iovec_array` will likely be replaced by something else. The
+;; linear-memory import will go away. typenames.witx will likely be obviated
+;; with better mechanisms for sharing types.
 
 (use "typenames.witx")
+
+;;; A handle providing reliable and in-order delivery of a stream of bytes
+;;; from an external source.
+(typename $input_byte_stream (handle))
+
+;;; A handle providing reliable and in-order delivery of a stream of bytes
+;;; to an external source.
+(typename $output_byte_stream (handle))
+
+;;; A handle representing the name of a stream. This is opaque, and does
+;;; not expose the actual string.
+(typename $pseudonym (handle))
 
 (module $wasi_ephemeral_io_streams
   ;;; Linear memory to be accessed by WASI functions that need it.
   (import "memory" (memory))
 
-  ;;; Read from a file descriptor.
-  ;;; Note: This is similar to `readv` in POSIX.
+  ;;; Read bytes from an input byte stream source.
+  ;;;
+  ;;; This function may read fewer bytes than requested if it reaches the
+  ;;; end of a stream or if an error occurs, and returns the number of
+  ;;; bytes read.
   (@interface func (export "read")
-    (param $fd $fd)
+    ;;; The input to read from.
+    (param $source $input_byte_stream)
     ;;; List of scatter/gather vectors to which to store data.
     (param $iovs $iovec_array)
     ;;; The number of bytes read.
-    (result $error (expected $size (error $errno)))
+    (result $num_read $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Consume bytes from an input byte stream source, discarding the data.
+  ;;;
+  ;;; This function may skip fewer bytes than requested if it reaches the
+  ;;; end of a stream or if an error occurs, and returns the number of
+  ;;; bytes skipped.
+  (@interface func (export "skip")
+    ;;; The input to skip in.
+    (param $source $input_byte_stream)
+    ;;; The number of bytes to skip over.
+    (param $len $size)
+    ;;; The number of bytes skipped.
+    (result $num_skipped $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Return the [Media Type] string for the input stream.
+  ;;;
+  ;;; The Media Type string is purely metadata, and makes no guarantee about
+  ;;; the validity of the data.
+  ;;;
+  ;;; Returns "*/*" if the Media Type is unknown.
+  ;;;
+  ;;; [Media Type]: https://www.iana.org/assignments/media-types/media-types.xhtml
+  (@interface func (export "input_media_type")
+    (param $source $input_byte_stream)
+
+    ;;; The buffer to which to write the contents of the symbolic link.
+    ;;; The buffer must be at least 255 bytes long.
+    ;;;
+    ;;; TODO: Replace this with `(result $result string)` instead.
+    (param $buf (@witx pointer (@witx char8)))
+    (param $buf_len $size)
+  )
+
+  ;;; Return the name for the input byte stream `$named`, as an abstract
+  ;;; handle, which can be written to the `$where` output byte stream.
+  ;;;
+  ;;; This allows the name of the input source to be passed into APIs
+  ;;; which display the name.
+  (@interface func (export "input_pseudonym")
+    ;;; The input byte stream to request a pseudonym for.
+    (param $named $input_byte_stream)
+    ;;; The output byte stream that the pseudonym may be written to.
+    (param $where $output_byte_stream)
+    ;;; The pseudonym.
+    (result $name $pseudonym)
   )
 
   ;;; Write to a file descriptor.
-  ;;; Note: This is similar to `writev` in POSIX.
   ;;;
-  ;;; Like POSIX, any calls of `write` (and other functions to read or write)
-  ;;; for a regular file by other threads in the WASI process should not be
-  ;;; interleaved while `write` is executed.
+  ;;; This function may write fewer bytes than requested if an error
+  ;;; occurs, and returns the number of bytes written.
   (@interface func (export "write")
-    (param $fd $fd)
+    ;;; The output to write to.
+    (param $sink $output_byte_stream)
     ;;; List of scatter/gather vectors from which to retrieve data.
     (param $iovs $ciovec_array)
     ;;; The number of bytes written.
-    (result $error (expected $size (error $errno)))
+    (result $num_written $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Write zeros to a file descriptor.
+  ;;;
+  ;;; This function may write fewer bytes than requested, and returns the
+  ;;; number of bytes written. fixme
+  ;;;
+  ;;; Note: This is analogous to `writev` in POSIX.
+  ;;;
+  ;;; Concurrent and otherwise unordered "write" calls to an
+  ;;; `output_byte_stream` handle are executed as if they were called
+  ;;; serially in a nondeterministic order.
+  (@interface func (export "write_zeros")
+    ;;; The output to write to.
+    (param $sink $output_byte_stream)
+    ;;; The number of zero bytes to write.
+    (param $len $size)
+    ;;; The number of bytes written.
+    (result $num_written $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Flush any pending output buffers and report any pending errors.
+  (@interface func (export "flush")
+    ;;; The output to write to.
+    (param $sink $output_byte_stream)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Return the [Media Type] string for the output stream.
+  ;;;
+  ;;; The Media Type string is purely metadata, and makes no guarantee about
+  ;;; the validity of the data.
+  ;;;
+  ;;; Returns "*/*" if the Media Type is unknown.
+  ;;;
+  ;;; [Media Type]: https://www.iana.org/assignments/media-types/media-types.xhtml
+  (@interface func (export "output_media_type")
+    (param $source $output_byte_stream)
+
+    ;;; The buffer to which to write the contents of the symbolic link.
+    ;;; The buffer must be at least 255 bytes long.
+    ;;;
+    ;;; TODO: Replace this with `(result $result string)` instead.
+    (param $buf (@witx pointer (@witx char8)))
+    (param $buf_len $size)
+  )
+
+  ;;; Return the name for the output byte stream `$named`, as an abstract
+  ;;; handle, which can be written to the `$where` output byte stream.
+  ;;;
+  ;;; This allows the name of the output sink to be passed into APIs
+  ;;; which display the name.
+  (@interface func (export "output_pseudonym")
+    ;;; The output byte stream to request a pseudonym for.
+    (param $source $output_byte_stream)
+    ;;; The output byte stream that the pseudonym may be written to.
+    (param $where $output_byte_stream)
+    ;;; The pseudonym.
+    (result $name $pseudonym)
+  )
+
+  ;;; Write a pseudonym's nameto the output stream.
+  ;;;
+  ;;; This function traps if the pseudonym is not one obtained from calling
+  ;;; `input_pseudonym` or `output_pseudonym` with a `$where` parameter of
+  ;;; `$source`.
+  ;;;
+  ;;; This allows the name of the output sink to be passed into APIs
+  ;;; which display the name in contexts where the name is already
+  ;;; exposed.
+  (@interface func (export "write_pseudonym")
+    (param $source $output_byte_stream)
+    (param $name $pseudonym)
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Forward all the subsequent data from an input stream to an output stream.
+  (@interface func (export "forward")
+    ;;; The input to read from.
+    (param $source $input_byte_stream)
+    ;;; The output to write to.
+    (param $sink $output_byte_stream)
+    ;;; The number of bytes read.
+    (result $num_read $size)
+    ;;; The number of bytes written.
+    (result $num_written $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Forward up to `$n` bytes from an input stream to an output stream.
+  (@interface func (export "forward_n")
+    ;;; The input to read from.
+    (param $source $input_byte_stream)
+    ;;; The output to write to.
+    (param $sink $output_byte_stream)
+    ;;; The maximum number of bytes to forward.
+    (param $len $size)
+    ;;; The number of bytes read.
+    (result $num_read $size)
+    ;;; The number of bytes written.
+    (result $num_written $size)
+    ;;; Success or error.
+    (result $result (expected (error $errno)))
+  )
+
+  ;;; Return an input stream and an output stream where the input is
+  ;;; transmitted to the output.
+  (@interface func (export "pipe")
+    (result $source $input_byte_stream)
+    (result $sink $output_byte_stream)
+  )
+
+  ;;; Return an output stream which discards data sent to it.
+  (@interface func (export "null")
+    (result $sink $output_byte_stream)
   )
 )

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -193,6 +193,10 @@
   ;;;
   ;;; This allows the name of the output sink to be passed into APIs
   ;;; which display the name.
+  ;;;
+  ;;; TODO: This needs to say something about how the name is displayed.
+  ;;; Can it include whitespace? Non-printing characters? Quotes?
+  ;;; Backslashes? What's the encoding? And more.
   (@interface func (export "output_pseudonym")
     ;;; The output byte stream to request a pseudonym for.
     (param $source $output_byte_stream)

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -1,21 +1,18 @@
 ;; WASI I/O Streams.
 ;;
 ;; I/O streams support reliable in-order delivery.
-;; 
+;;
 ;; Currently this interface only supports streams of bytes, and datagram
 ;; sockets and out-of-band messages are not supported. In the future, with
 ;; appropriate interface types support, it's expected that this interface
 ;; will support streams of arbitrary type as well, which could be implemented
 ;; on top of datagram sockets.
 ;;
-;; Functions in this API are never return `errno::intr`.
-;;
 ;; Many parts of this file are expected to evolve, as witx evolves, as
 ;; interface types evolves, and as the I/O Types concepts themselves evolve.
 ;; For example, `iovec_array` will likely be replaced by something else. The
 ;; linear-memory import will go away. typenames.witx will likely be obviated
-;; with better mechanisms for sharing types. `$errno` will likely be
-;; replaced by a dedicated error type.
+;; with better mechanisms for sharing types.
 
 (use "typenames.witx")
 
@@ -31,13 +28,27 @@
 ;;; not expose the actual string.
 (typename $pseudonym (handle))
 
-;;; A flag indicating whether the end of an input stream has been reached.
-(typename $end_of_stream
+;;; The status of a stream after a read.
+(typename $read_status
   (enum (@witx tag u8)
-    ;;; The end of stream has not yet been reached.
+    ;;; The stream is ready for further reads.
+    ;;;
+    ;;; This code also implies that the `$size` returned from a read is equal
+    ;;; to the requested size.
     $ready
 
-    ;;; The end of stream has been reached.
+    ;;; Push - The stream is ready for further reads, however the source has
+    ;;; performed a flush. Consumers are encouraged to process the available
+    ;;; data before attempting further reads.
+    ;;;
+    ;;; This may also indicate that a failure has been detected after some
+    ;;; amount of data has been consumed. The data is returned successfully
+    ;;; with a `$push`, and the next `read` or `skip` call will report the
+    ;;; failure.
+    $push
+
+    ;;; The end of stream has been reached. No further data will be available
+    ;;; and subsequent attempts to read will fail.
     $end
   )
 )
@@ -48,44 +59,40 @@
 
   ;;; Read bytes from an input byte stream source.
   ;;;
-  ;;; End-of-stream and errors are "sticky":
-  ;;;  - On success, this function returns a flag indicating whether the end of
-  ;;;    the stream was reached. After it is reached, all subsequent `read` and
-  ;;;    `skip` calls always succeed and consume 0 bytes.
-  ;;;  - On failure, this function returns an error code, and all subsequent
-  ;;;    `read` and `skip` calls always consume 0 bytes and fail with
-  ;;;    `errno::badf`.
+  ;;; On success, `$size` indicates the number of bytes read, and
+  ;;; `$read_status` indicates the state of the stream.
+  ;;;
+  ;;; When `$read_status` is `$read`, `$size` is equal to the total buffer size
+  ;;; of `$iovs`.
+  ;;;
+  ;;; When `$read_status` is `$end`, or on failure, subsequent calls to `read`
+  ;;; and `skip` on the stream will fail.
   (@interface func (export "read")
     ;;; The input to read from.
     (param $source $input_byte_stream)
     ;;; List of scatter/gather vectors to which to store data.
     (param $iovs $iovec_array)
-    ;;; The number of bytes read.
-    (result $num_read $size)
-    ;;; On success, returns a flag indicating whether the end of the stream was
-    ;;; encountered. On failure, returns an error code.
-    (result $result (expected $end_of_stream (error $errno)))
+    ;;; On success, returns the number of bytes read plus the stream status.
+    (result $result (expected (tuple $size $read_status) (error)))
   )
 
   ;;; Consume bytes from an input byte stream source, discarding the data.
   ;;;
-  ;;; End-of-stream and errors are "sticky":
-  ;;;  - On success, this function returns a flag indicating whether the end of
-  ;;;    the stream was reached. After it is reached, all subsequent `read` and
-  ;;;    `skip` calls always succeed and consume 0 bytes.
-  ;;;  - On failure, this function returns an error code, and all subsequent
-  ;;;    `read` and `skip` calls always consume 0 bytes and fail with
-  ;;;    `errno::badf`.
+  ;;; On success, `$size` indicates the number of bytes read, and
+  ;;; `$read_status` indicates the state of the stream.
+  ;;;
+  ;;; When `$read_status` is `$read`, `$size` is equal to the total buffer size
+  ;;; of `$iovs`.
+  ;;;
+  ;;; When `$read_status` is `$end`, or on failure, subsequent calls to `read`
+  ;;; and `skip` on the stream will fail.
   (@interface func (export "skip")
     ;;; The input to skip in.
     (param $source $input_byte_stream)
     ;;; The number of bytes to skip over.
     (param $len $size)
-    ;;; The number of bytes skipped.
-    (result $num_skipped $size)
-    ;;; On success, returns a flag indicating whether the end of the stream was
-    ;;; encountered. On failure, returns an error code.
-    (result $result (expected $end_of_stream (error $errno)))
+    ;;; On success, returns the number of bytes read plus the stream status.
+    (result $result (expected (tuple $size $read_status) (error)))
   )
 
   ;;; Return the [Media Type] string for the input stream.
@@ -123,42 +130,28 @@
 
   ;;; Write to an output stream.
   ;;;
-  ;;; `$num_written` indicates how many bytes were successfully transmitted,
-  ;;; which is equal to `$len` on success, or less than `$len` on failure.
-  ;;;
-  ;;; Errors are "sticky":
-  ;;;  - On failure, this function returns an error code, and all subsequent
-  ;;;    `write` and `write_zeros` calls always write 0 bytes, fail, and
-  ;;;    return `errno::badf`.
+  ;;; On failure, subsequent calls to `write`, `write_zeros`, or
+  ;;; `write_pseudonym` on the stream will fail.
   (@interface func (export "write")
     ;;; The output to write to.
     (param $sink $output_byte_stream)
     ;;; List of scatter/gather vectors from which to retrieve data.
     (param $iovs $ciovec_array)
-    ;;; The number of bytes written.
-    (result $num_written $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; Indicate success or failure.
+    (result $result (expected (error)))
   )
 
   ;;; Write zeros to an output stream.
   ;;;
-  ;;; `$num_written` indicates how many bytes were successfully transmitted,
-  ;;; which is equal to `$len` on success, or less than `$len` on failure.
-  ;;;
-  ;;; Errors are "sticky":
-  ;;;  - On failure, this function returns an error code, and all subsequent
-  ;;;    `write` and `write_zeros` calls always write 0 bytes, fail, and
-  ;;;    return `errno::badf`.
+  ;;; On failure, subsequent calls to `write`, `write_zeros`, or
+  ;;; `write_pseudonym` on the stream will fail.
   (@interface func (export "write_zeros")
     ;;; The output to write to.
     (param $sink $output_byte_stream)
     ;;; The number of zero bytes to write.
     (param $len $size)
-    ;;; The number of bytes written.
-    (result $num_written $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; Indicate success or failure.
+    (result $result (expected (error)))
   )
 
   ;;; Flush any pending output buffers and report any pending errors.
@@ -166,7 +159,7 @@
     ;;; The output to write to.
     (param $sink $output_byte_stream)
     ;;; Success or error.
-    (result $result (expected (error $errno)))
+    (result $result (expected (error)))
   )
 
   ;;; Return the [Media Type] string for the output stream.
@@ -218,7 +211,7 @@
   (@interface func (export "write_pseudonym")
     (param $source $output_byte_stream)
     (param $name $pseudonym)
-    (result $result (expected (error $errno)))
+    (result $result (expected (error)))
   )
 
   ;;; Forward all the subsequent data from an input stream to an output stream.

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -215,20 +215,22 @@
   )
 
   ;;; Forward all the subsequent data from an input stream to an output stream.
+  ;;;
+  ;;; If a failure occurs on the output stream, the remaining data from the
+  ;;; input stream is consumed and discarded.
   (@interface func (export "forward")
     ;;; The input to read from.
     (param $source $input_byte_stream)
     ;;; The output to write to.
     (param $sink $output_byte_stream)
-    ;;; The number of bytes read.
-    (result $num_read $size)
-    ;;; The number of bytes written.
-    (result $num_written $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; On success, return the number of bytes forwarded.
+    (result $result (expected $size (error)))
   )
 
   ;;; Forward up to `$n` bytes from an input stream to an output stream.
+  ;;;
+  ;;; If a failure occurs on the output stream, the remaining data from the
+  ;;; input stream is consumed and discarded.
   (@interface func (export "forward_n")
     ;;; The input to read from.
     (param $source $input_byte_stream)
@@ -236,12 +238,8 @@
     (param $sink $output_byte_stream)
     ;;; The maximum number of bytes to forward.
     (param $len $size)
-    ;;; The number of bytes read.
-    (result $num_read $size)
-    ;;; The number of bytes written.
-    (result $num_written $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; On success, returns the number of bytes forwarded plus the stream status.
+    (result $result (expected (tuple $size $read_status) (error)))
   )
 
   ;;; Return an input stream and an output stream where the input is

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -4,7 +4,8 @@
 ;; interface types evolves, and as the I/O Types concepts themselves evolve.
 ;; For example, `iovec_array` will likely be replaced by something else. The
 ;; linear-memory import will go away. typenames.witx will likely be obviated
-;; with better mechanisms for sharing types.
+;; with better mechanisms for sharing types. `$errno` will likely be
+;; replaced by a dedicated error type.
 
 (use "typenames.witx")
 

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -62,7 +62,7 @@
   ;;; On success, `$size` indicates the number of bytes read, and
   ;;; `$read_status` indicates the state of the stream.
   ;;;
-  ;;; When `$read_status` is `$read`, `$size` is equal to the total buffer size
+  ;;; When `$read_status` is `$ready`, `$size` is equal to the total buffer size
   ;;; of `$iovs`.
   ;;;
   ;;; When `$read_status` is `$end`, or on failure, subsequent calls to `read`
@@ -81,7 +81,7 @@
   ;;; On success, `$size` indicates the number of bytes read, and
   ;;; `$read_status` indicates the state of the stream.
   ;;;
-  ;;; When `$read_status` is `$read`, `$size` is equal to the total buffer size
+  ;;; When `$read_status` is `$ready`, `$size` is equal to the total buffer size
   ;;; of `$iovs`.
   ;;;
   ;;; When `$read_status` is `$end`, or on failure, subsequent calls to `read`
@@ -199,7 +199,7 @@
     (result $name $pseudonym)
   )
 
-  ;;; Write a pseudonym's nameto the output stream.
+  ;;; Write a pseudonym's name to the output stream.
   ;;;
   ;;; This function traps if the pseudonym is not one obtained from calling
   ;;; `input_pseudonym` or `output_pseudonym` with a `$where` parameter of
@@ -209,8 +209,11 @@
   ;;; which display the name in contexts where the name is already
   ;;; exposed.
   (@interface func (export "write_pseudonym")
+    ;;; The output to write to.
     (param $source $output_byte_stream)
+    ;;; The pseudonym representing the name to write.
     (param $name $pseudonym)
+    ;;; Indicate success or failure.
     (result $result (expected (error)))
   )
 
@@ -227,7 +230,7 @@
     (result $result (expected $size (error)))
   )
 
-  ;;; Forward up to `$n` bytes from an input stream to an output stream.
+  ;;; Forward up to `$len` bytes from an input stream to an output stream.
   ;;;
   ;;; If a failure occurs on the output stream, the remaining data from the
   ;;; input stream is consumed and discarded.
@@ -245,12 +248,15 @@
   ;;; Return an input stream and an output stream where the input is
   ;;; transmitted to the output.
   (@interface func (export "pipe")
+    ;;; A stream for reading from the created pipe.
     (result $source $input_byte_stream)
+    ;;; A stream for writing to the created pipe.
     (result $sink $output_byte_stream)
   )
 
   ;;; Return an output stream which discards data sent to it.
   (@interface func (export "null")
+    ;;; A stream for writing bytes to be discarded.
     (result $sink $output_byte_stream)
   )
 )

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -100,7 +100,7 @@
     (result $name $pseudonym)
   )
 
-  ;;; Write to a file descriptor.
+  ;;; Write to an output stream.
   ;;;
   ;;; `$num_written` indicates how many bytes were successfully transmitted,
   ;;; which is equal to `$len` on success, or less than `$len` on failure.
@@ -120,7 +120,7 @@
     (result $result (expected (error $errno)))
   )
 
-  ;;; Write zeros to a file descriptor.
+  ;;; Write zeros to an output stream.
   ;;;
   ;;; `$num_written` indicates how many bytes were successfully transmitted,
   ;;; which is equal to `$len` on success, or less than `$len` on failure.

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -1,5 +1,15 @@
 ;; WASI I/O Streams.
 ;;
+;; I/O streams support reliable in-order delivery.
+;; 
+;; Currently this interface only supports streams of bytes, and datagram
+;; sockets and out-of-band messages are not supported. In the future, with
+;; appropriate interface types support, it's expected that this interface
+;; will support streams of arbitrary type as well, which could be implemented
+;; on top of datagram sockets.
+;;
+;; Functions in this API are never return `errno::intr`.
+;;
 ;; Many parts of this file are expected to evolve, as witx evolves, as
 ;; interface types evolves, and as the I/O Types concepts themselves evolve.
 ;; For example, `iovec_array` will likely be replaced by something else. The
@@ -21,6 +31,17 @@
 ;;; not expose the actual string.
 (typename $pseudonym (handle))
 
+;;; A flag indicating whether the end of an input stream has been reached.
+(typename $end_of_stream
+  (enum (@witx tag u8)
+    ;;; The end of stream has not yet been reached.
+    $ready
+
+    ;;; The end of stream has been reached.
+    $end
+  )
+)
+
 (module $wasi_ephemeral_io_streams
   ;;; Linear memory to be accessed by WASI functions that need it.
   (import "memory" (memory))
@@ -28,7 +49,7 @@
   ;;; Read bytes from an input byte stream source.
   ;;;
   ;;; End-of-stream and errors are "sticky":
-  ;;;  - On success, this function returns a bool indicating whether the end of
+  ;;;  - On success, this function returns a flag indicating whether the end of
   ;;;    the stream was reached. After it is reached, all subsequent `read` and
   ;;;    `skip` calls always succeed and consume 0 bytes.
   ;;;  - On failure, this function returns an error code, and all subsequent
@@ -41,15 +62,15 @@
     (param $iovs $iovec_array)
     ;;; The number of bytes read.
     (result $num_read $size)
-    ;;; On success, returns a bool indicating whether the end of the stream was
+    ;;; On success, returns a flag indicating whether the end of the stream was
     ;;; encountered. On failure, returns an error code.
-    (result $result (expected bool (error $errno)))
+    (result $result (expected $end_of_stream (error $errno)))
   )
 
   ;;; Consume bytes from an input byte stream source, discarding the data.
   ;;;
   ;;; End-of-stream and errors are "sticky":
-  ;;;  - On success, this function returns a bool indicating whether the end of
+  ;;;  - On success, this function returns a flag indicating whether the end of
   ;;;    the stream was reached. After it is reached, all subsequent `read` and
   ;;;    `skip` calls always succeed and consume 0 bytes.
   ;;;  - On failure, this function returns an error code, and all subsequent
@@ -62,9 +83,9 @@
     (param $len $size)
     ;;; The number of bytes skipped.
     (result $num_skipped $size)
-    ;;; On success, returns a bool indicating whether the end of the stream was
+    ;;; On success, returns a flag indicating whether the end of the stream was
     ;;; encountered. On failure, returns an error code.
-    (result $result (expected bool (error $errno)))
+    (result $result (expected $end_of_stream (error $errno)))
   )
 
   ;;; Return the [Media Type] string for the input stream.

--- a/standard/io/witx/io_streams.witx
+++ b/standard/io/witx/io_streams.witx
@@ -27,9 +27,13 @@
 
   ;;; Read bytes from an input byte stream source.
   ;;;
-  ;;; This function may read fewer bytes than requested if it reaches the
-  ;;; end of a stream or if an error occurs, and returns the number of
-  ;;; bytes read.
+  ;;; End-of-stream and errors are "sticky":
+  ;;;  - On success, this function returns a bool indicating whether the end of
+  ;;;    the stream was reached. After it is reached, all subsequent `read` and
+  ;;;    `skip` calls always succeed and consume 0 bytes.
+  ;;;  - On failure, this function returns an error code, and all subsequent
+  ;;;    `read` and `skip` calls always consume 0 bytes and fail with
+  ;;;    `errno::badf`.
   (@interface func (export "read")
     ;;; The input to read from.
     (param $source $input_byte_stream)
@@ -37,15 +41,20 @@
     (param $iovs $iovec_array)
     ;;; The number of bytes read.
     (result $num_read $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; On success, returns a bool indicating whether the end of the stream was
+    ;;; encountered. On failure, returns an error code.
+    (result $result (expected bool (error $errno)))
   )
 
   ;;; Consume bytes from an input byte stream source, discarding the data.
   ;;;
-  ;;; This function may skip fewer bytes than requested if it reaches the
-  ;;; end of a stream or if an error occurs, and returns the number of
-  ;;; bytes skipped.
+  ;;; End-of-stream and errors are "sticky":
+  ;;;  - On success, this function returns a bool indicating whether the end of
+  ;;;    the stream was reached. After it is reached, all subsequent `read` and
+  ;;;    `skip` calls always succeed and consume 0 bytes.
+  ;;;  - On failure, this function returns an error code, and all subsequent
+  ;;;    `read` and `skip` calls always consume 0 bytes and fail with
+  ;;;    `errno::badf`.
   (@interface func (export "skip")
     ;;; The input to skip in.
     (param $source $input_byte_stream)
@@ -53,8 +62,9 @@
     (param $len $size)
     ;;; The number of bytes skipped.
     (result $num_skipped $size)
-    ;;; Success or error.
-    (result $result (expected (error $errno)))
+    ;;; On success, returns a bool indicating whether the end of the stream was
+    ;;; encountered. On failure, returns an error code.
+    (result $result (expected bool (error $errno)))
   )
 
   ;;; Return the [Media Type] string for the input stream.
@@ -92,8 +102,13 @@
 
   ;;; Write to a file descriptor.
   ;;;
-  ;;; This function may write fewer bytes than requested if an error
-  ;;; occurs, and returns the number of bytes written.
+  ;;; `$num_written` indicates how many bytes were successfully transmitted,
+  ;;; which is equal to `$len` on success, or less than `$len` on failure.
+  ;;;
+  ;;; Errors are "sticky":
+  ;;;  - On failure, this function returns an error code, and all subsequent
+  ;;;    `write` and `write_zeros` calls always write 0 bytes, fail, and
+  ;;;    return `errno::badf`.
   (@interface func (export "write")
     ;;; The output to write to.
     (param $sink $output_byte_stream)
@@ -107,14 +122,13 @@
 
   ;;; Write zeros to a file descriptor.
   ;;;
-  ;;; This function may write fewer bytes than requested, and returns the
-  ;;; number of bytes written. fixme
+  ;;; `$num_written` indicates how many bytes were successfully transmitted,
+  ;;; which is equal to `$len` on success, or less than `$len` on failure.
   ;;;
-  ;;; Note: This is analogous to `writev` in POSIX.
-  ;;;
-  ;;; Concurrent and otherwise unordered "write" calls to an
-  ;;; `output_byte_stream` handle are executed as if they were called
-  ;;; serially in a nondeterministic order.
+  ;;; Errors are "sticky":
+  ;;;  - On failure, this function returns an error code, and all subsequent
+  ;;;    `write` and `write_zeros` calls always write 0 bytes, fail, and
+  ;;;    return `errno::badf`.
   (@interface func (export "write_zeros")
     ;;; The output to write to.
     (param $sink $output_byte_stream)

--- a/tools/witx/src/abi.rs
+++ b/tools/witx/src/abi.rs
@@ -328,9 +328,8 @@ impl Abi {
         results: &[InterfaceFuncParam],
     ) -> Result<(), String> {
         assert_eq!(*self, Abi::Preview1);
-        match results.len() {
-            0 => {}
-            1 => match &**results[0].tref.type_() {
+        for result in results {
+            match &**result.tref.type_() {
                 Type::Handle(_) | Type::Builtin(_) | Type::ConstPointer(_) | Type::Pointer(_) => {}
                 Type::Variant(v) => {
                     let (ok, err) = match v.as_expected() {
@@ -370,8 +369,7 @@ impl Abi {
                 }
                 Type::Record(r) if r.bitflags_repr().is_some() => {}
                 Type::Record(_) | Type::List(_) => return Err("invalid return type".to_string()),
-            },
-            _ => return Err("more than one result".to_string()),
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This also extends the ABI validator to allow multiple return types, as
are used in the I/O streams interface.