### PR TITLE
Change `write-repeated` to `write-zeroes`.

### DIFF
--- a/wasi-io.abi.md
+++ b/wasi-io.abi.md
@@ -85,14 +85,13 @@ Size: 0, Alignment: 1
 
 #### <a href="#output_stream_write_repeated" name="output_stream_write_repeated"></a> `output-stream::write-repeated` 
 
-  Write a single byte multiple times to a stream.
+  Write multiple zero bytes to a stream.
   
-  This function returns a `u64` indicating the number of copies of
-  `byte` that were written; it may be less than `len`.
+  This function returns a `u64` indicating the number of zero bytes
+  that were written; it may be less than `len`.
 ##### Params
 
 - <a href="#output_stream_write_repeated.self" name="output_stream_write_repeated.self"></a> `self`: handle<output-stream>
-- <a href="#output_stream_write_repeated.byte" name="output_stream_write_repeated.byte"></a> `byte`: `u8`
 - <a href="#output_stream_write_repeated.len" name="output_stream_write_repeated.len"></a> `len`: `u64`
 ##### Results
 

--- a/wasi-io.wit.md
+++ b/wasi-io.wit.md
@@ -85,16 +85,14 @@ resource output-stream {
     ) -> result<u64, stream-error>
 ```
 
-## `write-repeated`
+## `write-zeroes`
 ```wit
-    /// Write a single byte multiple times to a stream.
+    /// Write multiple zero bytes to a stream.
     ///
-    /// This function returns a `u64` indicating the number of copies of
-    /// `byte` that were written; it may be less than `len`.
+    /// This function returns a `u64` indicating the number of zero bytes
+    /// that were written; it may be less than `len`.
     write-repeated: func(
-        /// The byte to write
-        byte: u8,
-        /// The number of times to write it
+        /// The number of zero bytes to write
         len: u64
     ) -> result<u64, stream-error>
 ```


### PR DESCRIPTION
The main use case for `write-repeated` is writing zeros to a bytestream. I had generalized it to `write-repeated` in anticipation of thinking about how it will generalize to typed streams in the future, as not all types have natural zero values. However, not all types can be naturally copied either, such as owned handles and streams. Consequently, I don't think we'll generalize this to a fully-general typed-stream function, so we can specialize it to its intended use case of just writing zeros to a stream.