### PR TITLE
Add a polling interface for streams.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-poll/75ace039473c05928cfd8e6df0243fc47ee9e8c9/wit/wasi-poll.wit.md > wit/wasi-poll.wit.md
     - uses: WebAssembly/wit-abi-up-to-date@v10
       with:
         wit-abi-tag: wit-abi-0.8.0

--- a/wasi-io.html
+++ b/wasi-io.html
@@ -1,5 +1,43 @@
+<h1>Import interface <code>wasi-poll</code></h1>
+<h2>Types</h2>
+<h2><a href="#pollable" name="pollable"></a> <a href="#pollable"><code>pollable</code></a>: <code>u32</code></h2>
+<p>A &quot;pollable&quot; handle.</p>
+<p>This is conceptually represents a <code>stream&lt;_, _&gt;</code>, or in other words,
+a stream that one can wait on, repeatedly, but which does not itself
+produce any data. It's temporary scaffolding until component-model's
+async features are ready.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p><a href="#pollable"><code>pollable</code></a> lifetimes are not automatically managed. Users must ensure
+that they do not outlive the resource they reference.</p>
+<p>Size: 4, Alignment: 4</p>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#poll_oneoff" name="poll_oneoff"></a> <a href="#poll_oneoff"><code>poll-oneoff</code></a></h4>
+<p>Poll for completion on a set of pollables.</p>
+<p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
+linear scan through the entire list of subscriptions, which may be
+inefficient if the number is large and the same subscriptions are used
+many times. In the future, it may be accompanied by an API similar to
+Linux's <code>epoll</code> which allows sets of subscriptions to be registered and
+made efficiently reusable.</p>
+<p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
+be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
+See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+for details.  For now, we use zero to mean &quot;not ready&quot; and non-zero to
+mean &quot;ready&quot;.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#poll_oneoff.in" name="poll_oneoff.in"></a> <code>in</code>: list&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#poll_oneoff.result0" name="poll_oneoff.result0"></a> <code>result0</code>: list&lt;<code>u8</code>&gt;</li>
+</ul>
 <h1>Import interface <code>wasi-io</code></h1>
 <h2>Types</h2>
+<h2><a href="#pollable" name="pollable"></a> <a href="#pollable"><code>pollable</code></a>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></h2>
+<p>Size: 4, Alignment: 4</p>
 <h2><a href="#stream_error" name="stream_error"></a> <a href="#stream_error"><code>stream-error</code></a>: record</h2>
 <p>An error type returned from a stream operation. Currently this
 doesn't provide any additional information.</p>
@@ -68,6 +106,18 @@ value will be at most <code>len</code>; it may be less.</p>
 <li><a href="#skip.result0" name="skip.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
+<h4><a href="#subscribe_read" name="subscribe_read"></a> <a href="#subscribe_read"><code>subscribe-read</code></a></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream has bytes
+available to read or the other end of the stream has been closed.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#subscribe_read.this" name="subscribe_read.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#subscribe_read.result0" name="subscribe_read.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+</ul>
+<hr />
 <h4><a href="#drop_input_stream" name="drop_input_stream"></a> <a href="#drop_input_stream"><code>drop-input-stream</code></a></h4>
 <p>Dispose of the specified <a href="#input_stream"><code>input-stream</code></a>, after which it may no longer
 be used.</p>
@@ -117,6 +167,18 @@ than <code>len</code>.</p>
 <h5>Results</h5>
 <ul>
 <li><a href="#splice.result0" name="splice.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#subscribe" name="subscribe"></a> <a href="#subscribe"><code>subscribe</code></a></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream is ready
+to accept bytes or the other end of the stream has been closed.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#subscribe.this" name="subscribe.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#subscribe.result0" name="subscribe.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <hr />
 <h4><a href="#drop_output_stream" name="drop_output_stream"></a> <a href="#drop_output_stream"><code>drop-output-stream</code></a></h4>

--- a/wasi-io.md
+++ b/wasi-io.md
@@ -1,6 +1,59 @@
+# Import interface `wasi-poll`
+
+## Types
+
+## <a href="#pollable" name="pollable"></a> `pollable`: `u32`
+
+A "pollable" handle.
+
+This is conceptually represents a `stream<_, _>`, or in other words,
+a stream that one can wait on, repeatedly, but which does not itself
+produce any data. It's temporary scaffolding until component-model's
+async features are ready.
+
+And at present, it is a `u32` instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.
+
+`pollable` lifetimes are not automatically managed. Users must ensure
+that they do not outlive the resource they reference.
+
+Size: 4, Alignment: 4
+
+## Functions
+
+----
+
+#### <a href="#poll_oneoff" name="poll_oneoff"></a> `poll-oneoff` 
+
+Poll for completion on a set of pollables.
+
+The "oneoff" in the name refers to the fact that this function must do a
+linear scan through the entire list of subscriptions, which may be
+inefficient if the number is large and the same subscriptions are used
+many times. In the future, it may be accompanied by an API similar to
+Linux's `epoll` which allows sets of subscriptions to be registered and
+made efficiently reusable.
+
+Note that the return type would ideally be `list<bool>`, but that would
+be more difficult to polyfill given the current state of `wit-bindgen`.
+See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+for details.  For now, we use zero to mean "not ready" and non-zero to
+mean "ready".
+##### Params
+
+- <a href="#poll_oneoff.in" name="poll_oneoff.in"></a> `in`: list<[`pollable`](#pollable)>
+##### Results
+
+- <a href="#poll_oneoff.result0" name="poll_oneoff.result0"></a> `result0`: list<`u8`>
+
 # Import interface `wasi-io`
 
 ## Types
+
+## <a href="#pollable" name="pollable"></a> `pollable`: [`pollable`](#pollable)
+
+
+Size: 4, Alignment: 4
 
 ## <a href="#stream_error" name="stream_error"></a> `stream-error`: record
 
@@ -95,6 +148,19 @@ value will be at most `len`; it may be less.
 
 ----
 
+#### <a href="#subscribe_read" name="subscribe_read"></a> `subscribe-read` 
+
+Create a `pollable` which will resolve once either the specified stream has bytes
+available to read or the other end of the stream has been closed.
+##### Params
+
+- <a href="#subscribe_read.this" name="subscribe_read.this"></a> `this`: [`input-stream`](#input_stream)
+##### Results
+
+- <a href="#subscribe_read.result0" name="subscribe_read.result0"></a> `result0`: [`pollable`](#pollable)
+
+----
+
 #### <a href="#drop_input_stream" name="drop_input_stream"></a> `drop-input-stream` 
 
 Dispose of the specified `input-stream`, after which it may no longer
@@ -151,6 +217,19 @@ than `len`.
 ##### Results
 
 - <a href="#splice.result0" name="splice.result0"></a> `result0`: result<(`u64`, `bool`), [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#subscribe" name="subscribe"></a> `subscribe` 
+
+Create a `pollable` which will resolve once either the specified stream is ready
+to accept bytes or the other end of the stream has been closed.
+##### Params
+
+- <a href="#subscribe.this" name="subscribe.this"></a> `this`: [`output-stream`](#output_stream)
+##### Results
+
+- <a href="#subscribe.result0" name="subscribe.result0"></a> `result0`: [`pollable`](#pollable)
 
 ----
 

--- a/wit/wasi-io.wit.md
+++ b/wit/wasi-io.wit.md
@@ -9,6 +9,11 @@
 default interface wasi-io {
 ```
 
+## Imports
+```wit
+use pkg.wasi-poll.{pollable}
+```
+
 ## `stream-error`
 ```wit
 /// An error type returned from a stream operation. Currently this
@@ -76,6 +81,13 @@ type input-stream = u32
         /// The maximum number of bytes to skip.
         len: u64,
     ) -> result<tuple<u64, bool>, stream-error>
+```
+
+## `subscribe`
+```wit
+/// Create a `pollable` which will resolve once either the specified stream has bytes
+/// available to read or the other end of the stream has been closed.
+subscribe-read: func(this: input-stream) -> pollable
 ```
 
 # `drop-input-stream`
@@ -155,6 +167,13 @@ type output-stream = u32
         /// The stream to read from
         src: input-stream
     ) -> result<u64, stream-error>
+```
+
+# `subscribe`
+```wit
+/// Create a `pollable` which will resolve once either the specified stream is ready
+/// to accept bytes or the other end of the stream has been closed.
+subscribe: func(this: output-stream) -> pollable
 ```
 
 # `drop-output-stream`


### PR DESCRIPTION
The new wasi-poll API has a `pollable` type. Add subscribe methods to the stream types to allow polling for stream events.

This adds a dependency on wasi-io, and is currently implemented in the repository in a low-tech way, which allows the generated documentation to work, though it's likely to evolve.