### PR TITLE
Rename the `subscribe` functions for consistency.

### DIFF
--- a/wasi-io.html
+++ b/wasi-io.html
@@ -106,16 +106,16 @@ value will be at most <code>len</code>; it may be less.</p>
 <li><a href="#skip.result0" name="skip.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#subscribe_read" name="subscribe_read"></a> <a href="#subscribe_read"><code>subscribe-read</code></a></h4>
+<h4><a href="#subscribe_to_input_stream" name="subscribe_to_input_stream"></a> <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream has bytes
 available to read or the other end of the stream has been closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#subscribe_read.this" name="subscribe_read.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a href="#subscribe_to_input_stream.this" name="subscribe_to_input_stream.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#subscribe_read.result0" name="subscribe_read.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a href="#subscribe_to_input_stream.result0" name="subscribe_to_input_stream.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <hr />
 <h4><a href="#drop_input_stream" name="drop_input_stream"></a> <a href="#drop_input_stream"><code>drop-input-stream</code></a></h4>
@@ -169,16 +169,16 @@ than <code>len</code>.</p>
 <li><a href="#splice.result0" name="splice.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#subscribe" name="subscribe"></a> <a href="#subscribe"><code>subscribe</code></a></h4>
+<h4><a href="#subscribe_to_output_stream" name="subscribe_to_output_stream"></a> <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream is ready
 to accept bytes or the other end of the stream has been closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#subscribe.this" name="subscribe.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#subscribe_to_output_stream.this" name="subscribe_to_output_stream.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#subscribe.result0" name="subscribe.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a href="#subscribe_to_output_stream.result0" name="subscribe_to_output_stream.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <hr />
 <h4><a href="#drop_output_stream" name="drop_output_stream"></a> <a href="#drop_output_stream"><code>drop-output-stream</code></a></h4>

--- a/wasi-io.md
+++ b/wasi-io.md
@@ -148,16 +148,16 @@ value will be at most `len`; it may be less.
 
 ----
 
-#### <a href="#subscribe_read" name="subscribe_read"></a> `subscribe-read` 
+#### <a href="#subscribe_to_input_stream" name="subscribe_to_input_stream"></a> `subscribe-to-input-stream` 
 
 Create a `pollable` which will resolve once either the specified stream has bytes
 available to read or the other end of the stream has been closed.
 ##### Params
 
-- <a href="#subscribe_read.this" name="subscribe_read.this"></a> `this`: [`input-stream`](#input_stream)
+- <a href="#subscribe_to_input_stream.this" name="subscribe_to_input_stream.this"></a> `this`: [`input-stream`](#input_stream)
 ##### Results
 
-- <a href="#subscribe_read.result0" name="subscribe_read.result0"></a> `result0`: [`pollable`](#pollable)
+- <a href="#subscribe_to_input_stream.result0" name="subscribe_to_input_stream.result0"></a> `result0`: [`pollable`](#pollable)
 
 ----
 
@@ -220,16 +220,16 @@ than `len`.
 
 ----
 
-#### <a href="#subscribe" name="subscribe"></a> `subscribe` 
+#### <a href="#subscribe_to_output_stream" name="subscribe_to_output_stream"></a> `subscribe-to-output-stream` 
 
 Create a `pollable` which will resolve once either the specified stream is ready
 to accept bytes or the other end of the stream has been closed.
 ##### Params
 
-- <a href="#subscribe.this" name="subscribe.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#subscribe_to_output_stream.this" name="subscribe_to_output_stream.this"></a> `this`: [`output-stream`](#output_stream)
 ##### Results
 
-- <a href="#subscribe.result0" name="subscribe.result0"></a> `result0`: [`pollable`](#pollable)
+- <a href="#subscribe_to_output_stream.result0" name="subscribe_to_output_stream.result0"></a> `result0`: [`pollable`](#pollable)
 
 ----
 

--- a/wit/wasi-io.wit.md
+++ b/wit/wasi-io.wit.md
@@ -83,11 +83,11 @@ type input-stream = u32
     ) -> result<tuple<u64, bool>, stream-error>
 ```
 
-## `subscribe`
+## `subscribe-to-input-stream`
 ```wit
 /// Create a `pollable` which will resolve once either the specified stream has bytes
 /// available to read or the other end of the stream has been closed.
-subscribe-read: func(this: input-stream) -> pollable
+subscribe-to-input-stream: func(this: input-stream) -> pollable
 ```
 
 # `drop-input-stream`
@@ -169,11 +169,11 @@ type output-stream = u32
     ) -> result<u64, stream-error>
 ```
 
-# `subscribe`
+# `subscribe-to-output-stream`
 ```wit
 /// Create a `pollable` which will resolve once either the specified stream is ready
 /// to accept bytes or the other end of the stream has been closed.
-subscribe: func(this: output-stream) -> pollable
+subscribe-to-output-stream: func(this: output-stream) -> pollable
 ```
 
 # `drop-output-stream`


### PR DESCRIPTION
Rename `subscribe`/`subscribe-read` to `subscribe-to-output-stream` and `subscribe-to-input-stream`, which makes them consistent and a little more self-explanatory.

In the future with resources these both might become just `subscribe` but for now the longer names keep them separate in the same namespace.