### PR TITLE
Add a `would-block` error code.

### DIFF
--- a/wasi-io.html
+++ b/wasi-io.html
@@ -45,11 +45,22 @@ mean &quot;ready&quot;.</p>
 <h2>Types</h2>
 <h2><a href="#pollable" name="pollable"></a> <a href="#pollable"><code>pollable</code></a>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></h2>
 <p>Size: 4, Alignment: 4</p>
-<h2><a href="#stream_error" name="stream_error"></a> <a href="#stream_error"><code>stream-error</code></a>: record</h2>
+<h2><a href="#stream_error" name="stream_error"></a> <a href="#stream_error"><code>stream-error</code></a>: enum</h2>
 <p>An error type returned from a stream operation. Currently this
-doesn't provide any additional information.</p>
-<p>Size: 0, Alignment: 1</p>
-<h3>Record Fields</h3>
+doesn't provide any additional information beyond whether the stream
+would block or not.</p>
+<p>Size: 1, Alignment: 1</p>
+<h3>Enum Cases</h3>
+<ul>
+<li>
+<p><a href="stream_error.error" name="stream_error.error"></a> <a href="#stream_error.error"><code>error</code></a></p>
+</li>
+<li>
+<p><a href="stream_error.would_block" name="stream_error.would_block"></a> <a href="#stream_error.would_block"><code>would-block</code></a></p>
+<p>The underlying stream is in a non-blocking mode, and a requested access
+to it would otherwise block.</p>
+</li>
+</ul>
 <h2><a href="#output_stream" name="output_stream"></a> <a href="#output_stream"><code>output-stream</code></a>: <code>u32</code></h2>
 <p>An output bytestream. In the future, this will be replaced by handle
 types.</p>

--- a/wasi-io.md
+++ b/wasi-io.md
@@ -64,15 +64,24 @@ mean "ready".
 
 Size: 4, Alignment: 4
 
-## <a href="#stream_error" name="stream_error"></a> `stream-error`: record
+## <a href="#stream_error" name="stream_error"></a> `stream-error`: enum
 
 An error type returned from a stream operation. Currently this
-doesn't provide any additional information.
+doesn't provide any additional information beyond whether the stream
+would block or not.
 
-Size: 0, Alignment: 1
+Size: 1, Alignment: 1
 
-### Record Fields
+### Enum Cases
 
+- <a href="stream_error.error" name="stream_error.error"></a> [`error`](#stream_error.error)
+  
+  
+- <a href="stream_error.would_block" name="stream_error.would_block"></a> [`would-block`](#stream_error.would_block)
+  
+  The underlying stream is in a non-blocking mode, and a requested access
+  to it would otherwise block.
+  
 ## <a href="#output_stream" name="output_stream"></a> `output-stream`: `u32`
 
 An output bytestream. In the future, this will be replaced by handle

--- a/wit/wasi-io.wit.md
+++ b/wit/wasi-io.wit.md
@@ -17,8 +17,16 @@ use pkg.wasi-poll.{pollable}
 ## `stream-error`
 ```wit
 /// An error type returned from a stream operation. Currently this
-/// doesn't provide any additional information.
-record stream-error {}
+/// doesn't provide any additional information beyond whether the stream
+/// would block or not.
+enum stream-error {
+    // An I/O error occurred.
+    error,
+
+    /// The underlying stream is in a non-blocking mode, and a requested access
+    /// to it would otherwise block.
+    would-block,
+}
 ```
 
 ## `input-stream`


### PR DESCRIPTION
Add an error code to stream I/O allowing it to indicate that the stream is in non-blocking mode and that a requested operation would otherwise block.