### PR TITLE
Make input-stream and output-stream always non-blocking.

### DIFF
--- a/wasi-io.html
+++ b/wasi-io.html
@@ -55,6 +55,12 @@ doesn't provide any additional information.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
+<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
+underlying platforms. Except where specified otherwise, I/O operations also
+always return promptly, after the number of bytes that can be written
+promptly, which could even be zero. To wait for the stream to be ready to
+accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
+<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -63,6 +69,12 @@ the wit-bindgen implementation of handles and resources is ready.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
+<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
+platforms. I/O operations always return promptly; if fewer bytes are
+promptly available than requested, they return the number of bytes promptly
+available, which could even be zero. To wait for data to be available,
+use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
+can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -165,6 +177,8 @@ that were written; it may be less than <code>len</code>.</p>
 <p>Read from one stream and write to another.</p>
 <p>This function returns the number of bytes transferred; it may be less
 than <code>len</code>.</p>
+<p>Unlike other I/O functions, this function blocks until all the data
+read from the input stream has been written to the output stream.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#splice.this" name="splice.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -181,6 +195,9 @@ than <code>len</code>.</p>
 <p>This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.</p>
+<p>Unlike other I/O functions, this function blocks until the end
+of the input stream is seen and all the data has been written to
+the output stream.</p>
 <p>This function returns the number of bytes transferred.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-io.md
+++ b/wasi-io.md
@@ -81,6 +81,13 @@ types.
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
 
+`output-stream`s are *non-blocking* to the extent practical on
+underlying platforms. Except where specified otherwise, I/O operations also
+always return promptly, after the number of bytes that can be written
+promptly, which could even be zero. To wait for the stream to be ready to
+accept data, the `subscribe-to-output-stream` function to obtain a
+`pollable` which can be polled for using `wasi_poll`.
+
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
 
@@ -93,6 +100,13 @@ types.
 
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
+
+`input-stream`s are *non-blocking* to the extent practical on underlying
+platforms. I/O operations always return promptly; if fewer bytes are
+promptly available than requested, they return the number of bytes promptly
+available, which could even be zero. To wait for data to be available,
+use the `subscribe-to-input-stream` function to obtain a `pollable` which
+can be polled for using `wasi_poll`.
 
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
@@ -218,6 +232,9 @@ Read from one stream and write to another.
 
 This function returns the number of bytes transferred; it may be less
 than `len`.
+
+Unlike other I/O functions, this function blocks until all the data
+read from the input stream has been written to the output stream.
 ##### Params
 
 - <a href="#splice.this" name="splice.this"></a> `this`: [`output-stream`](#output_stream)
@@ -236,6 +253,10 @@ Forward the entire contents of an input stream to an output stream.
 This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.
+
+Unlike other I/O functions, this function blocks until the end
+of the input stream is seen and all the data has been written to
+the output stream.
 
 This function returns the number of bytes transferred.
 ##### Params

--- a/wit/wasi-io.wit.md
+++ b/wit/wasi-io.wit.md
@@ -29,6 +29,13 @@ record stream-error {}
 /// This conceptually represents a `stream<u8, _>`. It's temporary
 /// scaffolding until component-model's async features are ready.
 ///
+/// `input-stream`s are *non-blocking* to the extent practical on underlying
+/// platforms. I/O operations always return promptly; if fewer bytes are
+/// promptly available than requested, they return the number of bytes promptly
+/// available, which could even be zero. To wait for data to be available,
+/// use the `subscribe-to-input-stream` function to obtain a `pollable` which
+/// can be polled for using `wasi_poll`.
+///
 /// And at present, it is a `u32` instead of being an actual handle, until
 /// the wit-bindgen implementation of handles and resources is ready.
 // TODO(resource input-stream {)
@@ -106,6 +113,13 @@ drop-input-stream: func(this: input-stream)
 /// This conceptually represents a `stream<u8, _>`. It's temporary
 /// scaffolding until component-model's async features are ready.
 ///
+/// `output-stream`s are *non-blocking* to the extent practical on
+/// underlying platforms. Except where specified otherwise, I/O operations also
+/// always return promptly, after the number of bytes that can be written
+/// promptly, which could even be zero. To wait for the stream to be ready to
+/// accept data, the `subscribe-to-output-stream` function to obtain a
+/// `pollable` which can be polled for using `wasi_poll`.
+///
 /// And at present, it is a `u32` instead of being an actual handle, until
 /// the wit-bindgen implementation of handles and resources is ready.
 // TODO(resource output-stream {)
@@ -144,6 +158,9 @@ type output-stream = u32
     ///
     /// This function returns the number of bytes transferred; it may be less
     /// than `len`.
+    ///
+    /// Unlike other I/O functions, this function blocks until all the data
+    /// read from the input stream has been written to the output stream.
     splice: func(
         this: output-stream,
         /// The stream to read from
@@ -160,6 +177,10 @@ type output-stream = u32
     /// This function repeatedly reads from the input stream and writes
     /// the data to the output stream, until the end of the input stream
     /// is reached, or an error is encountered.
+    ///
+    /// Unlike other I/O functions, this function blocks until the end
+    /// of the input stream is seen and all the data has been written to
+    /// the output stream.
     ///
     /// This function returns the number of bytes transferred.
     forward: func(


### PR DESCRIPTION
Specify that reads and writes are always non-blocking, to the extent practical on underlying platforms. This is closer to how the future builtin `stream` type will work, and should be more convenient for users doing async I/O.

To do blocking reads or writes, use a `poll_oneoff` to wait if an initial read or write didn't transmit any data. The first example in the README.md gives an example of how to do this.

It also eliminates the need for a `would-block` error, as `would-block` can be translated to a result of 0 bytes being transmitted. As such, this is an alternative to #23.