### PR TITLE
Add explicit blocking functions.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -124,6 +124,19 @@ FIXME: describe what happens if allocation fails.</p>
 <ul>
 <li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
+<h4><a name="blocking_read"><code>blocking-read: func</code></a></h4>
+<p>Read bytes from a stream, with blocking.</p>
+<p>This is similar to <a href="#read"><code>read</code></a>, except that it blocks until at least one
+byte can be read.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="blocking_read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="blocking_read.len"><code>len</code></a>: <code>u64</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
 <h4><a name="skip"><code>skip: func</code></a></h4>
 <p>Skip bytes from a stream.</p>
 <p>This is similar to the <a href="#read"><code>read</code></a> function, but avoids copying the
@@ -142,6 +155,19 @@ value will be at most <code>len</code>; it may be less.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="skip.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<h4><a name="blocking_skip"><code>blocking-skip: func</code></a></h4>
+<p>Skip bytes from a stream, with blocking.</p>
+<p>This is similar to <a href="#skip"><code>skip</code></a>, except that it blocks until at least one
+byte can be consumed.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="blocking_skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="blocking_skip.len"><code>len</code></a>: <code>u64</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="blocking_skip.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="subscribe_to_input_stream"><code>subscribe-to-input-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
@@ -175,6 +201,19 @@ be used.</p>
 <ul>
 <li><a name="write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
+<h4><a name="blocking_write"><code>blocking-write: func</code></a></h4>
+<p>Write bytes to a stream, with blocking.</p>
+<p>This is similar to <a href="#write"><code>write</code></a>, except that it blocks until at least one
+byte can be written.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="blocking_write.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="blocking_write.buf"><code>buf</code></a>: list&lt;<code>u8</code>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="blocking_write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
 <h4><a name="write_zeroes"><code>write-zeroes: func</code></a></h4>
 <p>Write multiple zero bytes to a stream.</p>
 <p>This function returns a <code>u64</code> indicating the number of zero bytes
@@ -187,6 +226,19 @@ that were written; it may be less than <code>len</code>.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<h4><a name="blocking_write_zeroes"><code>blocking-write-zeroes: func</code></a></h4>
+<p>Write multiple zero bytes to a stream, with blocking.</p>
+<p>This is similar to <a href="#write_zeroes"><code>write-zeroes</code></a>, except that it blocks until at least
+one byte can be written.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="blocking_write_zeroes.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="blocking_write_zeroes.len"><code>len</code></a>: <code>u64</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="blocking_write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="splice"><code>splice: func</code></a></h4>
 <p>Read from one stream and write to another.</p>
@@ -203,6 +255,20 @@ read from the input stream has been written to the output stream.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="splice.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<h4><a name="blocking_splice"><code>blocking-splice: func</code></a></h4>
+<p>Read from one stream and write to another, with blocking.</p>
+<p>This is similar to <a href="#splice"><code>splice</code></a>, except that it blocks until at least
+one byte can be read.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="blocking_splice.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a name="blocking_splice.src"><code>src</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a name="blocking_splice.len"><code>len</code></a>: <code>u64</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="blocking_splice.0"></a> result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="forward"><code>forward: func</code></a></h4>
 <p>Forward the entire contents of an input stream to an output stream.</p>

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -53,6 +53,16 @@ default interface streams {
         len: u64
     ) -> result<tuple<list<u8>, bool>, stream-error>
 
+    /// Read bytes from a stream, with blocking.
+    ///
+    /// This is similar to `read`, except that it blocks until at least one
+    /// byte can be read.
+    blocking-read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
     /// Skip bytes from a stream.
     ///
     /// This is similar to the `read` function, but avoids copying the
@@ -66,6 +76,16 @@ default interface streams {
     /// indicating whether the end of the stream was reached. The returned
     /// value will be at most `len`; it may be less.
     skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Skip bytes from a stream, with blocking.
+    ///
+    /// This is similar to `skip`, except that it blocks until at least one
+    /// byte can be consumed.
+    blocking-skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
@@ -109,11 +129,31 @@ default interface streams {
         buf: list<u8>
     ) -> result<u64, stream-error>
 
+    /// Write bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write`, except that it blocks until at least one
+    /// byte can be written.
+    blocking-write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
     /// Write multiple zero bytes to a stream.
     ///
     /// This function returns a `u64` indicating the number of zero bytes
     /// that were written; it may be less than `len`.
     write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write-zeroes`, except that it blocks until at least
+    /// one byte can be written.
+    blocking-write-zeroes: func(
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
@@ -127,6 +167,18 @@ default interface streams {
     /// Unlike other I/O functions, this function blocks until all the data
     /// read from the input stream has been written to the output stream.
     splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until at least
+    /// one byte can be read.
+    blocking-splice: func(
         this: output-stream,
         /// The stream to read from
         src: input-stream,


### PR DESCRIPTION
With #24 making streams always non-blocking, add functions to make it easy for users to use streams in blocking ways. This way, callers chose whether to block or not by calling the `blocking`- or regular non-blocking functions.

Along with #24, this switches wasi-io streams from having blockingness as a dynamic flag associated with a stream, to being an API choice that callers make in their choice of which function to use.