### PR TITLE
Add stream-status to stream write return values, and expand documentation

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -159,9 +159,9 @@ bytes into the instance.</p>
 <p>Once a stream has reached the end, subsequent calls to read or
 <a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
 data.</p>
-<p>This function returns the number of bytes skipped, along with a bool
-indicating whether the end of the stream was reached. The returned
-value will be at most <code>len</code>; it may be less.</p>
+<p>This function returns the number of bytes skipped, along with a
+<a href="#stream_status"><code>stream-status</code></a> indicating whether the end of the stream was
+reached. The returned value will be at most <code>len</code>; it may be less.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>

--- a/example-world.md
+++ b/example-world.md
@@ -84,16 +84,6 @@ When writing, this indicates that the stream will no longer be read.
 Further writes are still permitted.
 </li>
 </ul>
-<h4><a name="stream_error"><code>record stream-error</code></a></h4>
-<p>An error type returned from a stream operation.</p>
-<p>TODO: need to figure out the actual contents of this error. Used to be
-an empty record but that's no longer allowed. The <code>dummy</code> field is
-only here to have this be a valid in the component model by being
-non-empty.</p>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="stream_error.dummy"><code>dummy</code></a>: <code>u32</code></li>
-</ul>
 <h4><a name="output_stream"><code>type output-stream</code></a></h4>
 <p><code>u32</code></p>
 <p>An output bytestream. In the future, this will be replaced by handle
@@ -141,10 +131,6 @@ the current <a href="#stream_status"><code>stream-status</code></a>.</p>
 is not possible to allocate in wasm32, or not desirable to allocate as
 as a return value by the callee. The callee may return a list of bytes
 less than <code>len</code> in size while more bytes are available for reading.</p>
-<p>Returning an empty list and <code>stream-status:open</code> indicates that no more
-bytes were available from the stream at that time. In that case the
-<a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> pollable will indicate when additional
-bytes are available for reading.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -152,12 +138,11 @@ bytes are available for reading.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="blocking_read"><code>blocking-read: func</code></a></h4>
-<p>Blocking read bytes from a stream.</p>
-<p>This is similar to <a href="#read"><code>read</code></a>, except that it blocks until at least one
-byte can be read.</p>
+<p>Read bytes from a stream, after blocking until at least one byte can
+be read. Except for blocking, identical to <a href="#read"><code>read</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="blocking_read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -165,7 +150,7 @@ byte can be read.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="skip"><code>skip: func</code></a></h4>
 <p>Skip bytes from a stream.</p>
@@ -184,12 +169,11 @@ value will be at most <code>len</code>; it may be less.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="blocking_skip"><code>blocking-skip: func</code></a></h4>
-<p>Blocking skip bytes from a stream.</p>
-<p>This is similar to <a href="#skip"><code>skip</code></a>, except that it blocks until at least one
-byte can be consumed.</p>
+<p>Skip bytes from a stream, after blocking until at least one byte
+can be skipped. Except for blocking behavior, identical to <a href="#skip"><code>skip</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="blocking_skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -197,7 +181,7 @@ byte can be consumed.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="subscribe_to_input_stream"><code>subscribe-to-input-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
@@ -245,7 +229,7 @@ may be promptly written.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="blocking_write"><code>blocking-write: func</code></a></h4>
 <p>Blocking write of bytes to a stream.</p>
@@ -258,7 +242,7 @@ byte can be written.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="write_zeroes"><code>write-zeroes: func</code></a></h4>
 <p>Write multiple zero-bytes to a stream.</p>
@@ -272,7 +256,7 @@ that were written; it may be less than <code>len</code>. Equivelant to a call to
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="blocking_write_zeroes"><code>blocking-write-zeroes: func</code></a></h4>
 <p>Write multiple zero bytes to a stream, with blocking.</p>
@@ -286,7 +270,7 @@ a list of zeroes of the given length.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="splice"><code>splice: func</code></a></h4>
 <p>Read from one stream and write to another.</p>
@@ -302,7 +286,7 @@ read from the input stream has been written to the output stream.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="blocking_splice"><code>blocking-splice: func</code></a></h4>
 <p>Read from one stream and write to another, with blocking.</p>
@@ -316,7 +300,7 @@ one byte can be read.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="forward"><code>forward: func</code></a></h4>
 <p>Forward the entire contents of an input stream to an output stream.</p>
@@ -335,7 +319,7 @@ the output stream.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="forward.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="forward.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
 </ul>
 <h4><a name="subscribe_to_output_stream"><code>subscribe-to-output-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream

--- a/example-world.md
+++ b/example-world.md
@@ -78,25 +78,32 @@ socket ends when the socket is closed.</p>
 </li>
 <li>
 <p><a name="stream_status.ended"><code>ended</code></a></p>
-<p>The stream has ended and will not produce any further data.
+<p>When reading, this indicates that the stream will not produce
+further data.
+When writing, this indicates that the stream will no longer be read.
+Further writes are still permitted.
 </li>
 </ul>
 <h4><a name="stream_error"><code>record stream-error</code></a></h4>
-<p>An error type returned from a stream operation. Currently this
-doesn't provide any additional information.</p>
+<p>An error type returned from a stream operation.</p>
+<p>TODO: need to figure out the actual contents of this error. Used to be
+an empty record but that's no longer allowed. The <code>dummy</code> field is
+only here to have this be a valid in the component model by being
+non-empty.</p>
 <h5>Record Fields</h5>
+<ul>
+<li><a name="stream_error.dummy"><code>dummy</code></a>: <code>u32</code></li>
+</ul>
 <h4><a name="output_stream"><code>type output-stream</code></a></h4>
 <p><code>u32</code></p>
 <p>An output bytestream. In the future, this will be replaced by handle
 types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
 <p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
 underlying platforms. Except where specified otherwise, I/O operations also
 always return promptly, after the number of bytes that can be written
 promptly, which could even be zero. To wait for the stream to be ready to
 accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
-<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
+<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi:poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
@@ -104,34 +111,40 @@ the wit-bindgen implementation of handles and resources is ready.</p>
 <p><code>u32</code></p>
 <p>An input bytestream. In the future, this will be replaced by handle
 types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
 <p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
 platforms. I/O operations always return promptly; if fewer bytes are
 promptly available than requested, they return the number of bytes promptly
 available, which could even be zero. To wait for data to be available,
 use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
-can be polled for using <code>wasi_poll</code>.</p>
+can be polled for using <code>wasi:poll/poll.poll_oneoff</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
 <hr />
 <h3>Functions</h3>
 <h4><a name="read"><code>read: func</code></a></h4>
-<p>Read bytes from a stream.</p>
+<p>Perform a non-blocking read from the stream.</p>
 <p>This function returns a list of bytes containing the data that was
-read, along with a <a href="#stream_status"><code>stream-status</code></a> which indicates whether the end of
-the stream was reached. The returned list will contain up to <code>len</code>
-bytes; it may return fewer than requested, but not more.</p>
-<p>Once a stream has reached the end, subsequent calls to read or
-<a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
+read, along with a <a href="#stream_status"><code>stream-status</code></a> which, indicates whether further
+reads are expected to produce data. The returned list will contain up to
+<code>len</code> bytes; it may return fewer than requested, but not more. An
+empty list and <code>stream-status:open</code> indicates no more data is
+available at this time, and that the pollable given by
+<a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> will be ready when more data is available.</p>
+<p>Once a stream has reached the end, subsequent calls to <a href="#read"><code>read</code></a> or
+<a href="#skip"><code>skip</code></a> will always report <code>stream-status:ended</code> rather than producing more
 data.</p>
-<p>If <code>len</code> is 0, it represents a request to read 0 bytes, which should
-always succeed, assuming the stream hasn't reached its end yet, and
-return an empty list.</p>
-<p>The len here is a <code>u64</code>, but some callees may not be able to allocate
-a buffer as large as that would imply.
-FIXME: describe what happens if allocation fails.</p>
+<p>When the caller gives a <code>len</code> of 0, it represents a request to read 0
+bytes. This read should  always succeed and return an empty list and
+the current <a href="#stream_status"><code>stream-status</code></a>.</p>
+<p>The <code>len</code> parameter is a <code>u64</code>, which could represent a list of u8 which
+is not possible to allocate in wasm32, or not desirable to allocate as
+as a return value by the callee. The callee may return a list of bytes
+less than <code>len</code> in size while more bytes are available for reading.</p>
+<p>Returning an empty list and <code>stream-status:open</code> indicates that no more
+bytes were available from the stream at that time. In that case the
+<a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> pollable will indicate when additional
+bytes are available for reading.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="read.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -142,7 +155,7 @@ FIXME: describe what happens if allocation fails.</p>
 <li><a name="read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="blocking_read"><code>blocking-read: func</code></a></h4>
-<p>Read bytes from a stream, with blocking.</p>
+<p>Blocking read bytes from a stream.</p>
 <p>This is similar to <a href="#read"><code>read</code></a>, except that it blocks until at least one
 byte can be read.</p>
 <h5>Params</h5>
@@ -161,9 +174,9 @@ bytes into the instance.</p>
 <p>Once a stream has reached the end, subsequent calls to read or
 <a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
 data.</p>
-<p>This function returns the number of bytes skipped, along with a
-<a href="#stream_status"><code>stream-status</code></a> indicating whether the end of the stream was
-reached. The returned value will be at most <code>len</code>; it may be less.</p>
+<p>This function returns the number of bytes skipped, along with a bool
+indicating whether the end of the stream was reached. The returned
+value will be at most <code>len</code>; it may be less.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="skip.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -174,7 +187,7 @@ reached. The returned value will be at most <code>len</code>; it may be less.</p
 <li><a name="skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="blocking_skip"><code>blocking-skip: func</code></a></h4>
-<p>Skip bytes from a stream, with blocking.</p>
+<p>Blocking skip bytes from a stream.</p>
 <p>This is similar to <a href="#skip"><code>skip</code></a>, except that it blocks until at least one
 byte can be consumed.</p>
 <h5>Params</h5>
@@ -189,7 +202,10 @@ byte can be consumed.</p>
 <h4><a name="subscribe_to_input_stream"><code>subscribe-to-input-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
 has bytes available to read or the other end of the stream has been
-closed.</p>
+closed.
+The created <a href="#pollable"><code>pollable</code></a> is a child resource of the <a href="#input_stream"><code>input-stream</code></a>.
+Implementations may trap if the <a href="#input_stream"><code>input-stream</code></a> is dropped before
+all derived <a href="#pollable"><code>pollable</code></a>s created with this function are dropped.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="subscribe_to_input_stream.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
@@ -200,15 +216,28 @@ closed.</p>
 </ul>
 <h4><a name="drop_input_stream"><code>drop-input-stream: func</code></a></h4>
 <p>Dispose of the specified <a href="#input_stream"><code>input-stream</code></a>, after which it may no longer
-be used.</p>
+be used.
+Implementations may trap if this <a href="#input_stream"><code>input-stream</code></a> is dropped while child
+<a href="#pollable"><code>pollable</code></a> resources are still alive.
+After this <a href="#input_stream"><code>input-stream</code></a> is dropped, implementations may report any
+corresponding <a href="#output_stream"><code>output-stream</code></a> has <code>stream-state.closed</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="drop_input_stream.this"><code>this</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
 </ul>
 <h4><a name="write"><code>write: func</code></a></h4>
-<p>Write bytes to a stream.</p>
-<p>This function returns a <code>u64</code> indicating the number of bytes from
-<code>buf</code> that were written; it may be less than the full list.</p>
+<p>Perform a non-blocking write of bytes to a stream.</p>
+<p>This function returns a <code>u64</code> and a <a href="#stream_status"><code>stream-status</code></a>. The <code>u64</code> indicates
+the number of bytes from <code>buf</code> that were written, which may be less than
+the length of <code>buf</code>. The <a href="#stream_status"><code>stream-status</code></a> indicates if further writes to
+the stream are expected to be read.</p>
+<p>When the returned <a href="#stream_status"><code>stream-status</code></a> is <code>open</code>, the <code>u64</code> return value may
+be less than the length of <code>buf</code>. This indicates that no more bytes may
+be written to the stream promptly. In that case the
+<a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> pollable will indicate when additional bytes
+may be promptly written.</p>
+<p>Writing an empty list must return a non-error result with <code>0</code> for the
+<code>u64</code> return value, and the current <a href="#stream_status"><code>stream-status</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="write.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -216,10 +245,10 @@ be used.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="blocking_write"><code>blocking-write: func</code></a></h4>
-<p>Write bytes to a stream, with blocking.</p>
+<p>Blocking write of bytes to a stream.</p>
 <p>This is similar to <a href="#write"><code>write</code></a>, except that it blocks until at least one
 byte can be written.</p>
 <h5>Params</h5>
@@ -229,12 +258,13 @@ byte can be written.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_write.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="write_zeroes"><code>write-zeroes: func</code></a></h4>
-<p>Write multiple zero bytes to a stream.</p>
-<p>This function returns a <code>u64</code> indicating the number of zero bytes
-that were written; it may be less than <code>len</code>.</p>
+<p>Write multiple zero-bytes to a stream.</p>
+<p>This function returns a <code>u64</code> indicating the number of zero-bytes
+that were written; it may be less than <code>len</code>. Equivelant to a call to
+<a href="#write"><code>write</code></a> with a list of zeroes of the given length.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="write_zeroes.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -242,12 +272,13 @@ that were written; it may be less than <code>len</code>.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="blocking_write_zeroes"><code>blocking-write-zeroes: func</code></a></h4>
 <p>Write multiple zero bytes to a stream, with blocking.</p>
 <p>This is similar to <a href="#write_zeroes"><code>write-zeroes</code></a>, except that it blocks until at least
-one byte can be written.</p>
+one byte can be written. Equivelant to a call to <a href="#blocking_write"><code>blocking-write</code></a> with
+a list of zeroes of the given length.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="blocking_write_zeroes.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -255,7 +286,7 @@ one byte can be written.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="blocking_write_zeroes.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="blocking_write_zeroes.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="splice"><code>splice: func</code></a></h4>
 <p>Read from one stream and write to another.</p>
@@ -295,7 +326,8 @@ is reached, or an error is encountered.</p>
 <p>Unlike other I/O functions, this function blocks until the end
 of the input stream is seen and all the data has been written to
 the output stream.</p>
-<p>This function returns the number of bytes transferred.</p>
+<p>This function returns the number of bytes transferred, and the status of
+the output stream.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="forward.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -303,11 +335,16 @@ the output stream.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="forward.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+<li><a name="forward.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="subscribe_to_output_stream"><code>subscribe-to-output-stream: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
-is ready to accept bytes or the other end of the stream has been closed.</p>
+is ready to accept bytes or the <code>stream-state</code> has become closed.</p>
+<p>Once the stream-state is closed, this pollable is always ready
+immediately.</p>
+<p>The created <a href="#pollable"><code>pollable</code></a> is a child resource of the <a href="#output_stream"><code>output-stream</code></a>.
+Implementations may trap if the <a href="#output_stream"><code>output-stream</code></a> is dropped before
+all derived <a href="#pollable"><code>pollable</code></a>s created with this function are dropped.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="subscribe_to_output_stream.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -318,7 +355,11 @@ is ready to accept bytes or the other end of the stream has been closed.</p>
 </ul>
 <h4><a name="drop_output_stream"><code>drop-output-stream: func</code></a></h4>
 <p>Dispose of the specified <a href="#output_stream"><code>output-stream</code></a>, after which it may no longer
-be used.</p>
+be used.
+Implementations may trap if this <a href="#output_stream"><code>output-stream</code></a> is dropped while
+child <a href="#pollable"><code>pollable</code></a> resources are still alive.
+After this <a href="#output_stream"><code>output-stream</code></a> is dropped, implementations may report any
+corresponding <a href="#input_stream"><code>input-stream</code></a> has <code>stream-state.closed</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="drop_output_stream.this"><code>this</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -8,16 +8,6 @@ package wasi:io
 interface streams {
     use wasi:poll/poll.{pollable}
 
-    /// An error type returned from a stream operation.
-    ///
-    /// TODO: need to figure out the actual contents of this error. Used to be
-    /// an empty record but that's no longer allowed. The `dummy` field is
-    /// only here to have this be a valid in the component model by being
-    /// non-empty.
-    record stream-error {
-      dummy: u32,
-    }
-
     /// Streams provide a sequence of data and then end; once they end, they
     /// no longer provide any further data.
     ///
@@ -76,7 +66,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, stream-status>, stream-error>
+    ) -> result<tuple<list<u8>, stream-status>>
 
     /// Read bytes from a stream, after blocking until at least one byte can
     /// be read. Except for blocking, identical to `read`.
@@ -84,7 +74,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, stream-status>, stream-error>
+    ) -> result<tuple<list<u8>, stream-status>>
 
     /// Skip bytes from a stream.
     ///
@@ -102,7 +92,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Skip bytes from a stream, after blocking until at least one byte
     /// can be skipped. Except for blocking behavior, identical to `skip`.
@@ -110,7 +100,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Create a `pollable` which will resolve once either the specified stream
     /// has bytes available to read or the other end of the stream has been
@@ -163,7 +153,7 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Blocking write of bytes to a stream.
     ///
@@ -173,7 +163,7 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Write multiple zero-bytes to a stream.
     ///
@@ -184,7 +174,7 @@ interface streams {
         this: output-stream,
         /// The number of zero-bytes to write
         len: u64
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Write multiple zero bytes to a stream, with blocking.
     ///
@@ -195,7 +185,7 @@ interface streams {
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Read from one stream and write to another.
     ///
@@ -210,7 +200,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Read from one stream and write to another, with blocking.
     ///
@@ -222,7 +212,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Forward the entire contents of an input stream to an output stream.
     ///
@@ -240,7 +230,7 @@ interface streams {
         this: output-stream,
         /// The stream to read from
         src: input-stream
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Create a `pollable` which will resolve once either the specified stream
     /// is ready to accept bytes or the `stream-state` has become closed.

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -72,21 +72,14 @@ interface streams {
     /// is not possible to allocate in wasm32, or not desirable to allocate as
     /// as a return value by the callee. The callee may return a list of bytes
     /// less than `len` in size while more bytes are available for reading.
-    ///
-    /// Returning an empty list and `stream-status:open` indicates that no more
-    /// bytes were available from the stream at that time. In that case the
-    /// `subscribe-to-input-stream` pollable will indicate when additional
-    /// bytes are available for reading.
     read: func(
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
     ) -> result<tuple<list<u8>, stream-status>, stream-error>
 
-    /// Blocking read bytes from a stream.
-    ///
-    /// This is similar to `read`, except that it blocks until at least one
-    /// byte can be read.
+    /// Read bytes from a stream, after blocking until at least one byte can
+    /// be read. Except for blocking, identical to `read`.
     blocking-read: func(
         this: input-stream,
         /// The maximum number of bytes to read
@@ -111,10 +104,8 @@ interface streams {
         len: u64,
     ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Blocking skip bytes from a stream.
-    ///
-    /// This is similar to `skip`, except that it blocks until at least one
-    /// byte can be consumed.
+    /// Skip bytes from a stream, after blocking until at least one byte
+    /// can be skipped. Except for blocking behavior, identical to `skip`.
     blocking-skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -85,9 +85,9 @@ interface streams {
     /// `skip` will always report end-of-stream rather than producing more
     /// data.
     ///
-    /// This function returns the number of bytes skipped, along with a bool
-    /// indicating whether the end of the stream was reached. The returned
-    /// value will be at most `len`; it may be less.
+    /// This function returns the number of bytes skipped, along with a
+    /// `stream-status` indicating whether the end of the stream was
+    /// reached. The returned value will be at most `len`; it may be less.
     skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -1,3 +1,5 @@
+package wasi:io
+
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
 ///
@@ -6,9 +8,15 @@
 interface streams {
     use wasi:poll/poll.{pollable}
 
-    /// An error type returned from a stream operation. Currently this
-    /// doesn't provide any additional information.
-    record stream-error {}
+    /// An error type returned from a stream operation.
+    ///
+    /// TODO: need to figure out the actual contents of this error. Used to be
+    /// an empty record but that's no longer allowed. The `dummy` field is
+    /// only here to have this be a valid in the component model by being
+    /// non-empty.
+    record stream-error {
+      dummy: u32,
+    }
 
     /// Streams provide a sequence of data and then end; once they end, they
     /// no longer provide any further data.
@@ -19,22 +27,22 @@ interface streams {
     enum stream-status {
         /// The stream is open and may produce further data.
         open,
-        /// The stream has ended and will not produce any further data.
+        /// When reading, this indicates that the stream will not produce
+        /// further data.
+        /// When writing, this indicates that the stream will no longer be read.
+        /// Further writes are still permitted.
         ended,
     }
 
     /// An input bytestream. In the future, this will be replaced by handle
     /// types.
     ///
-    /// This conceptually represents a `stream<u8, _>`. It's temporary
-    /// scaffolding until component-model's async features are ready.
-    ///
     /// `input-stream`s are *non-blocking* to the extent practical on underlying
     /// platforms. I/O operations always return promptly; if fewer bytes are
     /// promptly available than requested, they return the number of bytes promptly
     /// available, which could even be zero. To wait for data to be available,
     /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
-    /// can be polled for using `wasi_poll`.
+    /// can be polled for using `wasi:poll/poll.poll_oneoff`.
     ///
     /// And at present, it is a `u32` instead of being an actual handle, until
     /// the wit-bindgen implementation of handles and resources is ready.
@@ -42,31 +50,40 @@ interface streams {
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
     type input-stream = u32
 
-    /// Read bytes from a stream.
+    /// Perform a non-blocking read from the stream.
     ///
     /// This function returns a list of bytes containing the data that was
-    /// read, along with a `stream-status` which indicates whether the end of
-    /// the stream was reached. The returned list will contain up to `len`
-    /// bytes; it may return fewer than requested, but not more.
-    ///
-    /// Once a stream has reached the end, subsequent calls to read or
-    /// `skip` will always report end-of-stream rather than producing more
+    /// read, along with a `stream-status` which, indicates whether further
+    /// reads are expected to produce data. The returned list will contain up to
+    /// `len` bytes; it may return fewer than requested, but not more. An
+    /// empty list and `stream-status:open` indicates no more data is
+    /// available at this time, and that the pollable given by
+    /// `subscribe-to-input-stream` will be ready when more data is available.
+    /// 
+    /// Once a stream has reached the end, subsequent calls to `read` or
+    /// `skip` will always report `stream-status:ended` rather than producing more
     /// data.
     ///
-    /// If `len` is 0, it represents a request to read 0 bytes, which should
-    /// always succeed, assuming the stream hasn't reached its end yet, and
-    /// return an empty list.
+    /// When the caller gives a `len` of 0, it represents a request to read 0
+    /// bytes. This read should  always succeed and return an empty list and
+    /// the current `stream-status`.
     ///
-    /// The len here is a `u64`, but some callees may not be able to allocate
-    /// a buffer as large as that would imply.
-    /// FIXME: describe what happens if allocation fails.
+    /// The `len` parameter is a `u64`, which could represent a list of u8 which
+    /// is not possible to allocate in wasm32, or not desirable to allocate as
+    /// as a return value by the callee. The callee may return a list of bytes
+    /// less than `len` in size while more bytes are available for reading.
+    ///
+    /// Returning an empty list and `stream-status:open` indicates that no more
+    /// bytes were available from the stream at that time. In that case the
+    /// `subscribe-to-input-stream` pollable will indicate when additional
+    /// bytes are available for reading.
     read: func(
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
     ) -> result<tuple<list<u8>, stream-status>, stream-error>
 
-    /// Read bytes from a stream, with blocking.
+    /// Blocking read bytes from a stream.
     ///
     /// This is similar to `read`, except that it blocks until at least one
     /// byte can be read.
@@ -85,16 +102,16 @@ interface streams {
     /// `skip` will always report end-of-stream rather than producing more
     /// data.
     ///
-    /// This function returns the number of bytes skipped, along with a
-    /// `stream-status` indicating whether the end of the stream was
-    /// reached. The returned value will be at most `len`; it may be less.
+    /// This function returns the number of bytes skipped, along with a bool
+    /// indicating whether the end of the stream was reached. The returned
+    /// value will be at most `len`; it may be less.
     skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
     ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Skip bytes from a stream, with blocking.
+    /// Blocking skip bytes from a stream.
     ///
     /// This is similar to `skip`, except that it blocks until at least one
     /// byte can be consumed.
@@ -107,24 +124,28 @@ interface streams {
     /// Create a `pollable` which will resolve once either the specified stream
     /// has bytes available to read or the other end of the stream has been
     /// closed.
+    /// The created `pollable` is a child resource of the `input-stream`.
+    /// Implementations may trap if the `input-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe-to-input-stream: func(this: input-stream) -> pollable
 
     /// Dispose of the specified `input-stream`, after which it may no longer
     /// be used.
+    /// Implementations may trap if this `input-stream` is dropped while child
+    /// `pollable` resources are still alive.
+    /// After this `input-stream` is dropped, implementations may report any
+    /// corresponding `output-stream` has `stream-state.closed`.
     drop-input-stream: func(this: input-stream)
 
     /// An output bytestream. In the future, this will be replaced by handle
     /// types.
-    ///
-    /// This conceptually represents a `stream<u8, _>`. It's temporary
-    /// scaffolding until component-model's async features are ready.
     ///
     /// `output-stream`s are *non-blocking* to the extent practical on
     /// underlying platforms. Except where specified otherwise, I/O operations also
     /// always return promptly, after the number of bytes that can be written
     /// promptly, which could even be zero. To wait for the stream to be ready to
     /// accept data, the `subscribe-to-output-stream` function to obtain a
-    /// `pollable` which can be polled for using `wasi_poll`.
+    /// `pollable` which can be polled for using `wasi:poll`.
     ///
     /// And at present, it is a `u32` instead of being an actual handle, until
     /// the wit-bindgen implementation of handles and resources is ready.
@@ -132,17 +153,28 @@ interface streams {
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
     type output-stream = u32
 
-    /// Write bytes to a stream.
+    /// Perform a non-blocking write of bytes to a stream.
     ///
-    /// This function returns a `u64` indicating the number of bytes from
-    /// `buf` that were written; it may be less than the full list.
+    /// This function returns a `u64` and a `stream-status`. The `u64` indicates
+    /// the number of bytes from `buf` that were written, which may be less than
+    /// the length of `buf`. The `stream-status` indicates if further writes to
+    /// the stream are expected to be read.
+    ///
+    /// When the returned `stream-status` is `open`, the `u64` return value may
+    /// be less than the length of `buf`. This indicates that no more bytes may
+    /// be written to the stream promptly. In that case the
+    /// `subscribe-to-output-stream` pollable will indicate when additional bytes
+    /// may be promptly written.
+    ///
+    /// Writing an empty list must return a non-error result with `0` for the
+    /// `u64` return value, and the current `stream-status`.
     write: func(
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<u64, stream-error>
+    ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Write bytes to a stream, with blocking.
+    /// Blocking write of bytes to a stream.
     ///
     /// This is similar to `write`, except that it blocks until at least one
     /// byte can be written.
@@ -150,27 +182,29 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<u64, stream-error>
+    ) -> result<tuple<u64, stream-status>, stream-error>
 
-    /// Write multiple zero bytes to a stream.
+    /// Write multiple zero-bytes to a stream.
     ///
-    /// This function returns a `u64` indicating the number of zero bytes
-    /// that were written; it may be less than `len`.
+    /// This function returns a `u64` indicating the number of zero-bytes
+    /// that were written; it may be less than `len`. Equivelant to a call to
+    /// `write` with a list of zeroes of the given length.
     write-zeroes: func(
         this: output-stream,
-        /// The number of zero bytes to write
+        /// The number of zero-bytes to write
         len: u64
-    ) -> result<u64, stream-error>
+    ) -> result<tuple<u64, stream-status>, stream-error>
 
     /// Write multiple zero bytes to a stream, with blocking.
     ///
     /// This is similar to `write-zeroes`, except that it blocks until at least
-    /// one byte can be written.
+    /// one byte can be written. Equivelant to a call to `blocking-write` with
+    /// a list of zeroes of the given length.
     blocking-write-zeroes: func(
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
-    ) -> result<u64, stream-error>
+    ) -> result<tuple<u64, stream-status>, stream-error>
 
     /// Read from one stream and write to another.
     ///
@@ -209,18 +243,30 @@ interface streams {
     /// of the input stream is seen and all the data has been written to
     /// the output stream.
     ///
-    /// This function returns the number of bytes transferred.
+    /// This function returns the number of bytes transferred, and the status of
+    /// the output stream.
     forward: func(
         this: output-stream,
         /// The stream to read from
         src: input-stream
-    ) -> result<u64, stream-error>
+    ) -> result<tuple<u64, stream-status>, stream-error>
 
     /// Create a `pollable` which will resolve once either the specified stream
-    /// is ready to accept bytes or the other end of the stream has been closed.
+    /// is ready to accept bytes or the `stream-state` has become closed.
+    ///
+    /// Once the stream-state is closed, this pollable is always ready
+    /// immediately.
+    ///
+    /// The created `pollable` is a child resource of the `output-stream`.
+    /// Implementations may trap if the `output-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe-to-output-stream: func(this: output-stream) -> pollable
 
     /// Dispose of the specified `output-stream`, after which it may no longer
     /// be used.
+    /// Implementations may trap if this `output-stream` is dropped while
+    /// child `pollable` resources are still alive.
+    /// After this `output-stream` is dropped, implementations may report any
+    /// corresponding `input-stream` has `stream-state.closed`.
     drop-output-stream: func(this: output-stream)
 }


### PR DESCRIPTION
Documentation focuses on how the non-blocking read and write functions respond when not ready for reading/writing, and how that maps to pollable.

~stream-error is now a record with a dummy member, to follow the new component model excluding zero-sized types.~

stream-error has been eliminated, since we can't determine any error value to provide there. All fallible funcs simply return `result<ok>` now, which can still represent an error but without any error type as the payload.

For more context on these changes: I designed and implemented them as part of https://github.com/bytecodealliance/wasmtime/pull/6556