### PR TITLE
input-stream uses result type like output-stream; single stream-error definition has error resource

### DIFF
--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -8,20 +8,36 @@ package wasi:io;
 interface streams {
     use poll.{pollable};
 
-    /// Streams provide a sequence of data and then end; once they end, they
-    /// no longer provide any further data.
+    /// An error for input-stream and output-stream operations.
+    variant stream-error {
+        /// The last operation (a write or flush) failed before completion.
+        ///
+        /// More information is available in the `error` payload.
+        last-operation-failed(error),
+        /// The stream is closed: no more input will be accepted by the
+        /// stream. A closed output-stream will return this error on all
+        /// future operations.
+        closed
+    }
+
+    /// Contextual error information about the last failure that happened on
+    /// a read, write, or flush from an `input-stream` or `output-stream`.
     ///
-    /// For example, a stream reading from a file ends when the stream reaches
-    /// the end of the file. For another example, a stream reading from a
-    /// socket ends when the socket is closed.
-    enum stream-status {
-        /// The stream is open and may produce further data.
-        open,
-        /// When reading, this indicates that the stream will not produce
-        /// further data.
-        /// When writing, this indicates that the stream will no longer be read.
-        /// Further writes are still permitted.
-        ended,
+    /// This type is returned through the `stream-error` type whenever an
+    /// operation on a stream directly fails or an error is discovered
+    /// after-the-fact, for example when a write's failure shows up through a
+    /// later `flush` or `check-write`.
+    ///
+    /// Interfaces such as `wasi:filesystem/types` provide functionality to
+    /// further "downcast" this error into interface-specific error information.
+    resource error {
+        /// Returns a string that's suitable to assist humans in debugging this
+        /// error.
+        ///
+        /// The returned string will change across platforms and hosts which
+        /// means that parsing it, for example, would be a
+        /// platform-compatibility hazard.
+        to-debug-string: func() -> string;
     }
 
     /// An input bytestream.
@@ -58,14 +74,14 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
         /// Skip bytes from a stream.
         ///
@@ -82,14 +98,14 @@ interface streams {
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -100,18 +116,6 @@ interface streams {
         subscribe: func() -> pollable;
     }
 
-    /// An error for output-stream operations.
-    ///
-    /// Contrary to input-streams, a closed output-stream is reported using
-    /// an error.
-    enum write-error {
-        /// The last operation (a write or flush) failed before completion.
-        last-operation-failed,
-        /// The stream is closed: no more input will be accepted by the
-        /// stream. A closed output-stream will return this error on all
-        /// future operations.
-        closed
-    }
 
     /// An output bytestream.
     ///
@@ -131,7 +135,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, write-error>;
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -142,7 +146,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -170,7 +174,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -182,11 +186,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, write-error>;
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, write-error>;
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -209,7 +213,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -238,7 +242,7 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
@@ -252,7 +256,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
@@ -263,7 +267,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Forward the entire contents of an input stream to an output stream.
         ///
@@ -280,6 +284,6 @@ interface streams {
         forward: func(
             /// The stream to read from
             src: input-stream
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
     }
 }


### PR DESCRIPTION
This PR includes two changes which were first made over in Wasmtime:

* The `input-stream` methods now return the same `stream-error`, fka `write-error`, as the `output-stream` methods. This change does eliminate the expression of input-stream.read to indicate both a successful read has completed, and the end of stream being reached. While that corner case will now take one additional call to `read`, the ergonomics are better and reflect what many client apis expect in e.g. libc. It also allows us to unify on one single `stream-error` type being returned across all input-stream and output-stream methods. We found that the implementation and tests changes for this interface change made both seem nicer, subjectively.

* `stream-error`'s `last-operation-failed` variant now contains a payload `resource error`. This implements the change described in https://github.com/WebAssembly/wasi-io/issues/47.