### PR TITLE
input-stream uses result type like output-stream; single stream-error definition has error resource

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -55,51 +55,45 @@ when it does, they are expected to subsume this API.</p>
 <h4><a name="pollable"><code>type pollable</code></a></h4>
 <p><a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></p>
 <p>
-#### <a name="stream_status">`enum stream-status`</a>
-<p>Streams provide a sequence of data and then end; once they end, they
-no longer provide any further data.</p>
-<p>For example, a stream reading from a file ends when the stream reaches
-the end of the file. For another example, a stream reading from a
-socket ends when the socket is closed.</p>
-<h5>Enum Cases</h5>
+#### <a name="error">`resource error`</a>
+<h4><a name="stream_error"><code>variant stream-error</code></a></h4>
+<p>An error for input-stream and output-stream operations.</p>
+<h5>Variant Cases</h5>
 <ul>
 <li>
-<p><a name="stream_status.open"><code>open</code></a></p>
-<p>The stream is open and may produce further data.
-</li>
-<li>
-<p><a name="stream_status.ended"><code>ended</code></a></p>
-<p>When reading, this indicates that the stream will not produce
-further data.
-When writing, this indicates that the stream will no longer be read.
-Further writes are still permitted.
-</li>
-</ul>
-<h4><a name="input_stream"><code>resource input-stream</code></a></h4>
-<h4><a name="write_error"><code>enum write-error</code></a></h4>
-<p>An error for output-stream operations.</p>
-<p>Contrary to input-streams, a closed output-stream is reported using
-an error.</p>
-<h5>Enum Cases</h5>
-<ul>
-<li>
-<p><a name="write_error.last_operation_failed"><code>last-operation-failed</code></a></p>
+<p><a name="stream_error.last_operation_failed"><code>last-operation-failed</code></a>: own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</p>
 <p>The last operation (a write or flush) failed before completion.
+<p>More information is available in the <a href="#error"><code>error</code></a> payload.</p>
 </li>
 <li>
-<p><a name="write_error.closed"><code>closed</code></a></p>
+<p><a name="stream_error.closed"><code>closed</code></a></p>
 <p>The stream is closed: no more input will be accepted by the
 stream. A closed output-stream will return this error on all
 future operations.
 </li>
 </ul>
+<h4><a name="input_stream"><code>resource input-stream</code></a></h4>
 <h4><a name="output_stream"><code>resource output-stream</code></a></h4>
 <hr />
 <h3>Functions</h3>
+<h4><a name="method_error.to_debug_string"><code>[method]error.to-debug-string: func</code></a></h4>
+<p>Returns a string that's suitable to assist humans in debugging this
+error.</p>
+<p>The returned string will change across platforms and hosts which
+means that parsing it, for example, would be a
+platform-compatibility hazard.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_error.to_debug_string.self"><code>self</code></a>: borrow&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="method_error.to_debug_string.0"></a> <code>string</code></li>
+</ul>
 <h4><a name="method_input_stream.read"><code>[method]input-stream.read: func</code></a></h4>
 <p>Perform a non-blocking read from the stream.</p>
 <p>This function returns a list of bytes containing the data that was
-read, along with a <a href="#stream_status"><code>stream-status</code></a> which, indicates whether further
+read, along with a <code>stream-status</code> which, indicates whether further
 reads are expected to produce data. The returned list will contain up to
 <code>len</code> bytes; it may return fewer than requested, but not more. An
 empty list and <code>stream-status:open</code> indicates no more data is
@@ -110,7 +104,7 @@ will be ready when more data is available.</p>
 data.</p>
 <p>When the caller gives a <code>len</code> of 0, it represents a request to read 0
 bytes. This read should  always succeed and return an empty list and
-the current <a href="#stream_status"><code>stream-status</code></a>.</p>
+the current <code>stream-status</code>.</p>
 <p>The <code>len</code> parameter is a <code>u64</code>, which could represent a list of u8 which
 is not possible to allocate in wasm32, or not desirable to allocate as
 as a return value by the callee. The callee may return a list of bytes
@@ -122,7 +116,7 @@ less than <code>len</code> in size while more bytes are available for reading.</
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_input_stream.read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_input_stream.read.0"></a> result&lt;list&lt;<code>u8</code>&gt;, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_input_stream.blocking_read"><code>[method]input-stream.blocking-read: func</code></a></h4>
 <p>Read bytes from a stream, after blocking until at least one byte can
@@ -134,7 +128,7 @@ be read. Except for blocking, identical to <code>read</code>.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_input_stream.blocking_read.0"></a> result&lt;(list&lt;<code>u8</code>&gt;, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_input_stream.blocking_read.0"></a> result&lt;list&lt;<code>u8</code>&gt;, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_input_stream.skip"><code>[method]input-stream.skip: func</code></a></h4>
 <p>Skip bytes from a stream.</p>
@@ -144,7 +138,7 @@ bytes into the instance.</p>
 <code>skip</code> will always report end-of-stream rather than producing more
 data.</p>
 <p>This function returns the number of bytes skipped, along with a
-<a href="#stream_status"><code>stream-status</code></a> indicating whether the end of the stream was
+<code>stream-status</code> indicating whether the end of the stream was
 reached. The returned value will be at most <code>len</code>; it may be less.</p>
 <h5>Params</h5>
 <ul>
@@ -153,7 +147,7 @@ reached. The returned value will be at most <code>len</code>; it may be less.</p
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_input_stream.skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_input_stream.skip.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_input_stream.blocking_skip"><code>[method]input-stream.blocking-skip: func</code></a></h4>
 <p>Skip bytes from a stream, after blocking until at least one byte
@@ -165,7 +159,7 @@ can be skipped. Except for blocking behavior, identical to <code>skip</code>.</p
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_input_stream.blocking_skip.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_input_stream.blocking_skip.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_input_stream.subscribe"><code>[method]input-stream.subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream
@@ -196,7 +190,7 @@ error.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.check_write.0"></a> result&lt;<code>u64</code>, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.check_write.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.write"><code>[method]output-stream.write: func</code></a></h4>
 <p>Perform a write. This function never blocks.</p>
@@ -211,7 +205,7 @@ the last call to check-write provided a permit.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.write.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.blocking_write_and_flush"><code>[method]output-stream.blocking-write-and-flush: func</code></a></h4>
 <p>Perform a write of up to 4096 bytes, and then flush the stream. Block
@@ -242,7 +236,7 @@ let _ = this.check-write();         // eliding error handling
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.blocking_write_and_flush.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write_and_flush.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.flush"><code>[method]output-stream.flush: func</code></a></h4>
 <p>Request to flush buffered output. This function never blocks.</p>
@@ -259,7 +253,7 @@ flush has completed and the stream can accept more writes.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.flush.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.flush.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.blocking_flush"><code>[method]output-stream.blocking-flush: func</code></a></h4>
 <p>Request to flush buffered output, and block until flush completes
@@ -270,7 +264,7 @@ and stream is ready for writing again.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.blocking_flush.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_flush.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.subscribe"><code>[method]output-stream.subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the output-stream
@@ -302,7 +296,7 @@ that should be written.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.write_zeroes.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.write_zeroes.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.blocking_write_zeroes_and_flush"><code>[method]output-stream.blocking-write-zeroes-and-flush: func</code></a></h4>
 <p>Perform a write of up to 4096 zeroes, and then flush the stream.
@@ -333,7 +327,7 @@ let _ = this.check-write();         // eliding error handling
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.blocking_write_zeroes_and_flush.0"></a> result&lt;_, <a href="#write_error"><a href="#write_error"><code>write-error</code></a></a>&gt;</li>
+<li><a name="method_output_stream.blocking_write_zeroes_and_flush.0"></a> result&lt;_, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.splice"><code>[method]output-stream.splice: func</code></a></h4>
 <p>Read from one stream and write to another.</p>
@@ -349,7 +343,7 @@ read from the input stream has been written to the output stream.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_output_stream.splice.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.blocking_splice"><code>[method]output-stream.blocking-splice: func</code></a></h4>
 <p>Read from one stream and write to another, with blocking.</p>
@@ -363,7 +357,7 @@ one byte can be read.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.blocking_splice.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_output_stream.blocking_splice.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_output_stream.forward"><code>[method]output-stream.forward: func</code></a></h4>
 <p>Forward the entire contents of an input stream to an output stream.</p>
@@ -382,5 +376,5 @@ the output stream.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_output_stream.forward.0"></a> result&lt;(<code>u64</code>, <a href="#stream_status"><a href="#stream_status"><code>stream-status</code></a></a>)&gt;</li>
+<li><a name="method_output_stream.forward.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -51,21 +51,20 @@ interface streams {
     resource input-stream {
         /// Perform a non-blocking read from the stream.
         ///
-        /// This function returns a list of bytes containing the data that was
-        /// read, along with a `stream-status` which, indicates whether further
-        /// reads are expected to produce data. The returned list will contain up to
-        /// `len` bytes; it may return fewer than requested, but not more. An
-        /// empty list and `stream-status:open` indicates no more data is
-        /// available at this time, and that the pollable given by `subscribe`
-        /// will be ready when more data is available.
+        /// This function returns a list of bytes containing the read data,
+        /// when successful. The returned list will contain up to `len` bytes;
+        /// it may return fewer than requested, but not more. The list is
+        /// empty when no bytes are available for reading at this time. The
+        /// pollable given by `subscribe` will be ready when more bytes are
+        /// available.
         ///
-        /// Once a stream has reached the end, subsequent calls to `read` or
-        /// `skip` will always report `stream-status:ended` rather than producing more
-        /// data.
+        /// This function fails with a `stream-error` when the operation
+        /// encounters an error, giving `last-operation-failed`, or when the
+        /// stream is closed, giving `closed`.
         ///
-        /// When the caller gives a `len` of 0, it represents a request to read 0
-        /// bytes. This read should  always succeed and return an empty list and
-        /// the current `stream-status`.
+        /// When the caller gives a `len` of 0, it represents a request to
+        /// read 0 bytes. If the stream is still open, this call should
+        /// succeed and return an empty list, or otherwise fail with `closed`.
         ///
         /// The `len` parameter is a `u64`, which could represent a list of u8 which
         /// is not possible to allocate in wasm32, or not desirable to allocate as
@@ -77,24 +76,16 @@ interface streams {
         ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
-        /// be read. Except for blocking, identical to `read`.
+        /// be read. Except for blocking, behavior is identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
         ) -> result<list<u8>, stream-error>;
 
-        /// Skip bytes from a stream.
+        /// Skip bytes from a stream. Returns number of bytes skipped.
         ///
-        /// This is similar to the `read` function, but avoids copying the
-        /// bytes into the instance.
-        ///
-        /// Once a stream has reached the end, subsequent calls to read or
-        /// `skip` will always report end-of-stream rather than producing more
-        /// data.
-        ///
-        /// This function returns the number of bytes skipped, along with a
-        /// `stream-status` indicating whether the end of the stream was
-        /// reached. The returned value will be at most `len`; it may be less.
+        /// Behaves identical to `read`, except instead of returning a list
+        /// of bytes, returns the number of bytes consumed from the stream.
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -8,20 +8,36 @@ package wasi:io;
 interface streams {
     use poll.{pollable};
 
-    /// Streams provide a sequence of data and then end; once they end, they
-    /// no longer provide any further data.
+    /// An error for input-stream and output-stream operations.
+    variant stream-error {
+        /// The last operation (a write or flush) failed before completion.
+        ///
+        /// More information is available in the `error` payload.
+        last-operation-failed(error),
+        /// The stream is closed: no more input will be accepted by the
+        /// stream. A closed output-stream will return this error on all
+        /// future operations.
+        closed
+    }
+
+    /// Contextual error information about the last failure that happened on
+    /// a read, write, or flush from an `input-stream` or `output-stream`.
     ///
-    /// For example, a stream reading from a file ends when the stream reaches
-    /// the end of the file. For another example, a stream reading from a
-    /// socket ends when the socket is closed.
-    enum stream-status {
-        /// The stream is open and may produce further data.
-        open,
-        /// When reading, this indicates that the stream will not produce
-        /// further data.
-        /// When writing, this indicates that the stream will no longer be read.
-        /// Further writes are still permitted.
-        ended,
+    /// This type is returned through the `stream-error` type whenever an
+    /// operation on a stream directly fails or an error is discovered
+    /// after-the-fact, for example when a write's failure shows up through a
+    /// later `flush` or `check-write`.
+    ///
+    /// Interfaces such as `wasi:filesystem/types` provide functionality to
+    /// further "downcast" this error into interface-specific error information.
+    resource error {
+        /// Returns a string that's suitable to assist humans in debugging this
+        /// error.
+        ///
+        /// The returned string will change across platforms and hosts which
+        /// means that parsing it, for example, would be a
+        /// platform-compatibility hazard.
+        to-debug-string: func() -> string;
     }
 
     /// An input bytestream.
@@ -58,14 +74,14 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
         /// Skip bytes from a stream.
         ///
@@ -82,14 +98,14 @@ interface streams {
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -100,18 +116,6 @@ interface streams {
         subscribe: func() -> pollable;
     }
 
-    /// An error for output-stream operations.
-    ///
-    /// Contrary to input-streams, a closed output-stream is reported using
-    /// an error.
-    enum write-error {
-        /// The last operation (a write or flush) failed before completion.
-        last-operation-failed,
-        /// The stream is closed: no more input will be accepted by the
-        /// stream. A closed output-stream will return this error on all
-        /// future operations.
-        closed
-    }
 
     /// An output bytestream.
     ///
@@ -131,7 +135,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, write-error>;
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -142,7 +146,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -170,7 +174,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -182,11 +186,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, write-error>;
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, write-error>;
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -209,7 +213,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -238,7 +242,7 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
@@ -252,7 +256,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
@@ -263,7 +267,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Forward the entire contents of an input stream to an output stream.
         ///
@@ -280,6 +284,6 @@ interface streams {
         forward: func(
             /// The stream to read from
             src: input-stream
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
     }
 }


### PR DESCRIPTION
Replaces #50 

This PR includes two changes which were first made over in Wasmtime:

The input-stream methods now return the same stream-error, fka write-error, as the output-stream methods. This change does eliminate the expression of input-stream.read to indicate both a successful read has completed, and the end of stream being reached. While that corner case will now take one additional call to read, the ergonomics are better and reflect what many client apis expect in e.g. libc. It also allows us to unify on one single stream-error type being returned across all input-stream and output-stream methods. We found that the implementation and tests changes for this interface change made both seem nicer, subjectively.

stream-error's last-operation-failed variant now contains a payload resource error. This implements the change described in https://github.com/WebAssembly/wasi-io/issues/47.