### PR TITLE
Update README.md: fill in Portability Criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ WASI-io is currently in [Phase 2].
 
 ### Portability Criteria
 
-WASI io must have host implementations which can pass the testsuite on at least Windows, macOS, and Linux.
+WASI I/O must have host implementations which can pass the testsuite on at least Windows, macOS, and Linux.
 
-WASI io must have at least two complete independent implementations.
+WASI I/O must have at least two complete independent implementations.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ WASI-io is currently in [Phase 2].
 
 ### Portability Criteria
 
-wasi-io must have host implementations which can pass the testsuite on at least Windows, macOS, and Linux.
+WASI io must have host implementations which can pass the testsuite on at least Windows, macOS, and Linux.
 
-wasi-io must have at least two complete independent implementations.
+WASI io must have at least two complete independent implementations.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ WASI-io is currently in [Phase 2].
 
 - Dan Gohman
 
-### Phase 4 Advancement Criteria
+### Portability Criteria
 
-WASI I/O has not yet proposed its phase-4 advancement criteria.
+wasi-io must have host implementations which can pass the testsuite on at least Windows, macOS, and Linux.
 
-We anticipate it will involve ensuring it works well for streaming files, sockets, and pipes, and is usable from wasi-libc for implementing POSIX APIs.
+wasi-io must have at least two complete independent implementations.
 
 ## Table of Contents
 


### PR DESCRIPTION
Phase 4 Advancement Criteria got renamed to Portability Criteria in https://github.com/WebAssembly/WASI/pull/549, so rename it in this document.

Also, this document never got the portability criteria filled in, but we have assigned it the same criteria as was filled in for wasi-poll, which got merged with this package in https://github.com/WebAssembly/wasi-io/pull/46