### PR TITLE
Make splice atomic

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -389,6 +389,9 @@ let _ = this.check-write();         // eliding error handling
 <code>check-write</code> permitted length and the <code>len</code> provided to <code>splice</code></li>
 <li>calling <code>write</code> on the <a href="#output_stream"><code>output-stream</code></a> with that read data.</li>
 </ol>
+<p>This function behaves as-if these steps are performed atomically.
+I.e. if the read (in step 2) succeeds, but the write (in step 3) fails,
+future reads will first read from the buffer alread retrieved in step 2.</p>
 <p>Any error reported by the call to <code>check-write</code>, <code>read</code>, or
 <code>write</code> ends the splice and reports that error.</p>
 <p>This function returns the number of bytes transferred; it may be less

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -235,6 +235,10 @@ interface streams {
         /// `check-write` permitted length and the `len` provided to `splice`
         /// 3. calling `write` on the `output-stream` with that read data.
         ///
+        /// This function behaves as-if these steps are performed atomically.
+        /// I.e. if the read (in step 2) succeeds, but the write (in step 3) fails,
+        /// future reads will first read from the buffer alread retrieved in step 2.
+        ///
         /// Any error reported by the call to `check-write`, `read`, or
         /// `write` ends the splice and reports that error.
         ///


### PR DESCRIPTION
Partly a PR, partly a question: what is supposed to happen with the already read data in case the `write` within `splice` fails?

Currently, wasmtime throws the data away.

Can we make it such that the `splice` implementation first reads into a per-stream stash and only then attempt to write it into the destination output stream? Future `read`s then first check if there is any data in its local stash, before calling the backing implementation.

I think this is in line with Linux' `splice` and `sendfile`