### PR TITLE
Proposal: add `output-stream::(blocking-)close`

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -325,9 +325,9 @@ and stream is ready for writing again.</p>
 </ul>
 <h4><a name="method_output_stream_subscribe"></a><code>[method]output-stream.subscribe: func</code></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the output-stream
-is ready for more writing, or an error has occurred. When this
-pollable is ready, <code>check-write</code> will return <code>ok(n)</code> with n&gt;0, or an
-error.</p>
+is ready for more writing, has closed, or an error has occurred.
+When this pollable is ready, <code>check-write</code> will return <code>ok(n)</code>
+with n&gt;0, or an error.</p>
 <p>If the stream is closed, this pollable is always ready immediately.</p>
 <p>The created <a href="#pollable"><code>pollable</code></a> is a child resource of the <a href="#output_stream"><code>output-stream</code></a>.
 Implementations may trap if the <a href="#output_stream"><code>output-stream</code></a> is dropped before

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -198,10 +198,27 @@ interface streams {
         @since(version = 0.2.0)
         blocking-flush: func() -> result<_, stream-error>;
 
+        /// Request to flush buffered output and initiate a graceful shutdown
+        /// afterwards. This function never blocks.
+        ///
+        /// This behaves similar to `flush` in that after calling this function,
+        /// the stream will not accept any new writes and `check-write` returns
+        /// `ok(0)` while the flushing & closing is in progress. Unlike `flush`,
+        /// the stream never reverts to being writable again. The `subscribe`
+        /// pollable will become ready when the stream has fully closed.
+        @unstable(feature = io-output-stream-close)
+        close: func() -> result<_, stream-error>;
+
+        /// Functionally equivalent to calling `close` and then blocking until
+        /// it actually has been closed. After this method returns, all methods
+        /// on this stream return `stream-error::closed`.
+        @unstable(feature = io-output-stream-close)
+        blocking-close: func() -> result<_, stream-error>;
+
         /// Create a `pollable` which will resolve once the output-stream
-        /// is ready for more writing, or an error has occurred. When this
-        /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
-        /// error.
+        /// is ready for more writing, has closed, or an error has occurred.
+        /// When this pollable is ready, `check-write` will return `ok(n)`
+        /// with n>0, or an error.
         ///
         /// If the stream is closed, this pollable is always ready immediately.
         ///


### PR DESCRIPTION
Today, there is no generic way to gracefully close a stream, other than to `drop` it and hope for the best.

Wasi-sockets already has an ad-hoc workaround in the form of `tcp-socket::shutdown(send)`. Similarly (but not exactly the same), wasi-http has `outgoing-body::finish`.

I'm currently sketching out a [TLS interface for WASI](https://github.com/WebAssembly/wasi-sockets/issues/100), where the TLS client/server does not perform any I/O on its own but instead acts as a stream transformer: cleartext data goes in, TLS data comes out, and vice versa. The stream transformer should not have to know where its inputs & outputs come from and go to. One thing that differentiates TLS from plain TCP is that a graceful shutdown requires additional I/O (a "close_notify" message to be sent).

One way to go about this is to add yet another set of bespoke methods on the TLS client/server resource type to close the output streams.
But preferably the end-of-stream indication should be propagated automagically.

I propose to add the ability to explicitly shut down a writable stream, asynchronously. This is not too far off from how existing programming environments work:

- Rust [`futures::io::AsyncWrite::poll_close`](https://docs.rs/futures/0.3.30/futures/io/trait.AsyncWrite.html#tymethod.poll_close)
- Rust [`tokio::io::AsyncWrite::poll_shutdown`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html#tymethod.poll_shutdown)
- .NET [`System.IO.Stream.DisposeAsync`](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.disposeasync?view=net-8.0)
- Node.JS [`stream.Writable.end`](https://nodejs.org/api/stream.html#writableendchunk-encoding-callback)
- ECMAScript [`asyncDispose`](https://github.com/tc39/proposal-explicit-resource-management?tab=readme-ov-file#whatwg-streams-api) (stage 3 proposal)
- Python [`asyncio.StreamWriter.close + wait_close`](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.close)

