### PR TITLE
fix typo: remove extra '}' in API walk-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ types, `input-stream`, and `output-stream`, which support `read` and
        }
        Ok(())
    }
-}
 ```
 
 #### Use case: copying from input to output using `splice`
@@ -113,7 +112,6 @@ types, `input-stream`, and `output-stream`, which support `read` and
        }
        Ok(())
    }
-}
 ```
 
 #### Use case: copying from input to output using `forward`
@@ -123,7 +121,6 @@ types, `input-stream`, and `output-stream`, which support `read` and
        output.forward(input)?;
        Ok(())
    }
-}
 ```
 
 ### Detailed design discussion


### PR DESCRIPTION
remove extra '}' in the end of code snippets