### PR TITLE
fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: wkg wit build -o wasi-io.wasm
 
       # Upload the Wasm binary to the GitHub registry
-      - uses: bytecodealliance/wkg-github-action@v3
+      - uses: bytecodealliance/wkg-github-action@v4
         with:
             oci-reference-without-tag: 'ghcr.io/webassembly/wasi/io'
             file: 'wasi-io.wasm'


### PR DESCRIPTION
attempt 4 at this; this bumps `wkg-oci-publish` to includes https://github.com/bytecodealliance/wkg-github-action/pull/4, which should fix the remaining OCI bugs. Thanks!