### PR TITLE
Unify the format of wit files

### DIFF
--- a/wit/poll.wit
+++ b/wit/poll.wit
@@ -8,19 +8,19 @@ interface poll {
     @since(version = 0.2.0)
     resource pollable {
 
-      /// Return the readiness of a pollable. This function never blocks.
-      ///
-      /// Returns `true` when the pollable is ready, and `false` otherwise.
-      @since(version = 0.2.0)
-      ready: func() -> bool;
+        /// Return the readiness of a pollable. This function never blocks.
+        ///
+        /// Returns `true` when the pollable is ready, and `false` otherwise.
+        @since(version = 0.2.0)
+        ready: func() -> bool;
 
-      /// `block` returns immediately if the pollable is ready, and otherwise
-      /// blocks until ready.
-      ///
-      /// This function is equivalent to calling `poll.poll` on a list
-      /// containing only this pollable.
-      @since(version = 0.2.0)
-      block: func();
+        /// `block` returns immediately if the pollable is ready, and otherwise
+        /// blocks until ready.
+        ///
+        /// This function is equivalent to calling `poll.poll` on a list
+        /// containing only this pollable.
+        @since(version = 0.2.0)
+        block: func();
     }
 
     /// Poll for completion on a set of pollables.


### PR DESCRIPTION
According to https://github.com/WebAssembly/WASI/pull/641, unify the code style of each project according to the dependency order.