### PR TITLE
Remove mention of "UTF-8" in output-stream.write()

### DIFF
--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -138,8 +138,7 @@ interface streams {
         /// When the destination of a `write` is binary data, the bytes from
         /// `contents` are written verbatim. When the destination of a `write` is
         /// known to the implementation to be text, the bytes of `contents` are
-        /// transcoded from UTF-8 into the encoding of the destination and then
-        /// written.
+        /// transcoded into the encoding of the destination and then written.
         ///
         /// Precondition: check-write gave permit of Ok(n) and contents has a
         /// length of less than or equal to n. Otherwise, this function will trap.


### PR DESCRIPTION
Does `output-stream.write()` know or care what the original encoding was? And does it have to be UTF-8?