### PR TITLE
Use `.` instead of `/` for interface members.

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -16,13 +16,13 @@
 <p>The only method provided by this resource is <code>to-debug-string</code>,
 which provides some human-readable information about the error.</p>
 <p>In the <code>wasi:io</code> package, this resource is returned through the
-<code>wasi:io/streams/stream-error</code> type.</p>
+<code>wasi:io/streams.stream-error</code> type.</p>
 <p>To provide more specific error information, other interfaces may
 offer functions to &quot;downcast&quot; this error into more specific types. For example,
 errors returned from streams derived from filesystem types can be described using
 the filesystem's own error-code type. This is done using the function
-<code>wasi:filesystem/types/filesystem-error-code</code>, which takes a <code>borrow&lt;error&gt;</code>
-parameter and returns an <code>option&lt;wasi:filesystem/types/error-code&gt;</code>.</p>
+<code>wasi:filesystem/types.filesystem-error-code</code>, which takes a <code>borrow&lt;error&gt;</code>
+parameter and returns an <code>option&lt;wasi:filesystem/types.error-code&gt;</code>.</p>
 <h2>The set of functions which can &quot;downcast&quot; an <a href="#error"><code>error</code></a> into a more
 concrete type is open.</h2>
 <h3>Functions</h3>

--- a/imports.md
+++ b/imports.md
@@ -104,10 +104,10 @@ when it does, they are expected to subsume this API.</p>
 <h4><a id="error"></a><code>type error</code></h4>
 <p><a href="#error"><a href="#error"><code>error</code></a></a></p>
 <p>
-<h4><a id="pollable"></a><code>type pollable</code></h4>
-<p><a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></p>
+#### <a id="pollable"></a>`type pollable`
+[`pollable`](#pollable)
 <p>
-<h4><a id="stream_error"></a><code>variant stream-error</code></h4>
+#### <a id="stream_error"></a>`variant stream-error`
 <p>An error for input-stream and output-stream operations.</p>
 <h5>Variant Cases</h5>
 <ul>

--- a/wit/error.wit
+++ b/wit/error.wit
@@ -8,14 +8,14 @@ interface error {
     /// which provides some human-readable information about the error.
     ///
     /// In the `wasi:io` package, this resource is returned through the
-    /// `wasi:io/streams/stream-error` type.
+    /// `wasi:io/streams.stream-error` type.
     ///
     /// To provide more specific error information, other interfaces may
     /// offer functions to "downcast" this error into more specific types. For example,
     /// errors returned from streams derived from filesystem types can be described using
     /// the filesystem's own error-code type. This is done using the function
-    /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-    /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+    /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+    /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
     ///
     /// The set of functions which can "downcast" an `error` into a more
     /// concrete type is open.


### PR DESCRIPTION
Say:
```
wasi:io/streams.stream-error
```
instead of:
```
wasi:io/streams/stream-error
```

This better aligns with WIT's `use` syntax and the upcoming nested namespaces feature in WIT.